### PR TITLE
[llvm] Add IndexStoreDB_ prefix to LLVMSupport to avoid conflicts

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -54,12 +54,12 @@ let package = Package(
     // Support code that is generally useful to the C++ implementation.
     .target(
       name: "IndexStoreDB_Support",
-      dependencies: ["LLVMSupport"],
+      dependencies: ["IndexStoreDB_LLVMSupport"],
       path: "lib/Support"),
 
     // Copy of a subset of llvm's ADT and Support libraries.
     .target(
-      name: "LLVMSupport",
+      name: "IndexStoreDB_LLVMSupport",
       dependencies: [],
       path: "lib/LLVMSupport"),
   ],


### PR DESCRIPTION
SwiftPM doesn't protect us from module name conflicts, and this happens
to collide with llbuild's names. Add a prefix to workaround.

See https://bugs.swift.org/browse/SR-9292