### PR TITLE
[config] Disable futimens to fix backward deployment issue

### DIFF
--- a/include/llvm/Config/config.h
+++ b/include/llvm/Config/config.h
@@ -75,7 +75,7 @@
 /* #undef HAVE_FFI_H */
 
 /* Define to 1 if you have the `futimens' function. */
-#define HAVE_FUTIMENS 1
+/* #undef HAVE_FUTIMENS */
 
 /* Define to 1 if you have the `futimes' function. */
 #define HAVE_FUTIMES 1


### PR DESCRIPTION
This API is available in macOS 10.13, but since this configuration is
fixed, we should be conservative. In practice the only effect this has
is to fix a warning while building this code on macOS, because the only
function that uses futimens is setLastModificationAndAccessTime, which
is not used anywhere in indexstore-db.