### PR TITLE
Add IndexStoreDB-dynamic library for users that want to force dynamic…

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -9,6 +9,10 @@ let package = Package(
       name: "IndexStoreDB",
       targets: ["IndexStoreDB"]),
     .library(
+      name: "IndexStoreDB-dynamic",
+      type: .dynamic,
+      targets: ["IndexStoreDB"]),
+    .library(
       name: "IndexStoreDB_CXX",
       targets: ["IndexStoreDB_Index"]),
   ],


### PR DESCRIPTION
… linking

Most users shouldn't care whether we're dynamically or statically
linked, and can use the existing IndexStoreDB library. For clients that
need to use a dynamic library, they can now use IndexStoreDB-dynamic.