### PR TITLE
[IndexDatastore] For the out-of-date trigger notifications report all the out-of-date files without any coalescing

### DIFF
--- a/include/IndexStoreDB/Index/IndexSystemDelegate.h
+++ b/include/IndexStoreDB/Index/IndexSystemDelegate.h
@@ -27,6 +27,7 @@ namespace index {
 class OutOfDateTriggerHint {
 public:
   virtual ~OutOfDateTriggerHint() {}
+  virtual std::string originalFileTrigger() = 0;
   virtual std::string description() = 0;
 
 private:
@@ -44,6 +45,7 @@ public:
     return std::make_shared<DependentFileOutOfDateTriggerHint>(filePath);
   }
 
+  virtual std::string originalFileTrigger() override;
   virtual std::string description() override;
 };
 
@@ -59,6 +61,7 @@ public:
     return std::make_shared<DependentUnitOutOfDateTriggerHint>(unitName, std::move(depHint));
   }
 
+  virtual std::string originalFileTrigger() override;
   virtual std::string description() override;
 };
 

--- a/lib/Index/IndexSystem.cpp
+++ b/lib/Index/IndexSystem.cpp
@@ -525,8 +525,16 @@ bool IndexSystemImpl::foreachFileIncludedByFile(StringRef SourcePath,
 
 void OutOfDateTriggerHint::_anchor() {}
 
+std::string DependentFileOutOfDateTriggerHint::originalFileTrigger() {
+  return FilePath;
+}
+
 std::string DependentFileOutOfDateTriggerHint::description() {
   return FilePath;
+}
+
+std::string DependentUnitOutOfDateTriggerHint::originalFileTrigger() {
+  return DepHint->originalFileTrigger();
 }
 
 std::string DependentUnitOutOfDateTriggerHint::description() {


### PR DESCRIPTION
Previously if there were multiple headers that got out-of-date and they were all included by the same main file, it would trigger a single notification for that main file. With these changes there will be notifications for each file.

This allows clients to get the full information of what needs to get updated and they get the responsibility for doing any kind of coalescing they want.