### PR TITLE
Remove all Uses of TimeValue

### DIFF
--- a/include/IndexStoreDB/Core/Symbol.h
+++ b/include/IndexStoreDB/Core/Symbol.h
@@ -23,7 +23,7 @@
 #include "llvm/ADT/StringRef.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/Support/DataTypes.h"
-#include "llvm/Support/TimeValue.h"
+#include "llvm/Support/Chrono.h"
 #include <memory>
 #include <string>
 
@@ -224,12 +224,12 @@ public:
 class TimestampedPath {
   std::string Path;
   std::string ModuleName;
-  llvm::sys::TimeValue ModificationTime;
+  llvm::sys::TimePoint<> ModificationTime;
   unsigned sysrootPrefixLength = 0;
   bool IsSystem;
 
 public:
-  TimestampedPath(StringRef Path, llvm::sys::TimeValue ModificationTime, StringRef moduleName, bool isSystem, CanonicalFilePathRef sysroot = {})
+  TimestampedPath(StringRef Path, llvm::sys::TimePoint<> ModificationTime, StringRef moduleName, bool isSystem, CanonicalFilePathRef sysroot = {})
     : Path(Path), ModuleName(moduleName), ModificationTime(ModificationTime), IsSystem(isSystem) {
     if (sysroot.contains(CanonicalFilePathRef::getAsCanonicalPath(Path))) {
       sysrootPrefixLength = sysroot.getPath().size();
@@ -237,7 +237,7 @@ public:
   }
 
   const std::string &getPathString() const { return Path; }
-  llvm::sys::TimeValue getModificationTime() const { return ModificationTime; }
+  llvm::sys::TimePoint<> getModificationTime() const { return ModificationTime; }
   const std::string &getModuleName() const { return ModuleName; }
   unsigned isSystem() const { return IsSystem; }
   StringRef getPathWithoutSysroot() const {

--- a/include/IndexStoreDB/Database/ImportTransaction.h
+++ b/include/IndexStoreDB/Database/ImportTransaction.h
@@ -54,7 +54,7 @@ class LLVM_EXPORT UnitDataImport {
   CanonicalFilePath MainFile;
   CanonicalFilePath OutFile;
   CanonicalFilePath Sysroot;
-  llvm::sys::TimeValue ModTime;
+  llvm::sys::TimePoint<> ModTime;
   Optional<bool> IsSystem;
   Optional<SymbolProviderKind> SymProviderKind;
   std::string Target;
@@ -75,7 +75,7 @@ class LLVM_EXPORT UnitDataImport {
   std::vector<UnitInfo::Provider> ProviderDepends;
 
 public:
-  UnitDataImport(ImportTransaction &import, StringRef unitName, llvm::sys::TimeValue modTime);
+  UnitDataImport(ImportTransaction &import, StringRef unitName, llvm::sys::TimePoint<> modTime);
   ~UnitDataImport();
 
   IDCode getUnitCode() const { return UnitCode; }

--- a/include/IndexStoreDB/Database/ReadTransaction.h
+++ b/include/IndexStoreDB/Database/ReadTransaction.h
@@ -45,9 +45,9 @@ public:
   bool getProviderFileReferences(IDCode provider,
                                  llvm::function_ref<bool(TimestampedPath path)> receiver);
   bool getProviderFileCodeReferences(IDCode provider,
-                                     llvm::function_ref<bool(IDCode pathCode, IDCode unitCode, llvm::sys::TimeValue modTime, IDCode moduleNameCode, bool isSystem)> receiver);
+                                     llvm::function_ref<bool(IDCode pathCode, IDCode unitCode, llvm::sys::TimePoint<> modTime, IDCode moduleNameCode, bool isSystem)> receiver);
   /// Returns all provider-file associations. Intended for debugging purposes.
-  bool foreachProviderAndFileCodeReference(llvm::function_ref<bool(IDCode provider, IDCode pathCode, IDCode unitCode, llvm::sys::TimeValue modTime, IDCode moduleNameCode, bool isSystem)> receiver);
+  bool foreachProviderAndFileCodeReference(llvm::function_ref<bool(IDCode provider, IDCode pathCode, IDCode unitCode, llvm::sys::TimePoint<> modTime, IDCode moduleNameCode, bool isSystem)> receiver);
 
   /// Returns USR codes in batches.
   bool foreachUSROfGlobalSymbolKind(SymbolKind symKind, llvm::function_ref<bool(ArrayRef<IDCode> usrCodes)> receiver);

--- a/include/IndexStoreDB/Database/UnitInfo.h
+++ b/include/IndexStoreDB/Database/UnitInfo.h
@@ -18,7 +18,7 @@
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/Hashing.h"
 #include "llvm/ADT/StringRef.h"
-#include "llvm/Support/TimeValue.h"
+#include "llvm/Support/Chrono.h"
 
 namespace IndexStoreDB {
 namespace db {
@@ -38,7 +38,7 @@ struct UnitInfo {
 
   StringRef UnitName;
   IDCode UnitCode;
-  llvm::sys::TimeValue ModTime;
+  llvm::sys::TimePoint<> ModTime;
   IDCode OutFileCode;
   IDCode MainFileCode;
   IDCode SysrootCode;

--- a/include/IndexStoreDB/Index/IndexSystem.h
+++ b/include/IndexStoreDB/Index/IndexSystem.h
@@ -16,7 +16,7 @@
 #include "IndexStoreDB/Support/LLVM.h"
 #include "llvm/ADT/OptionSet.h"
 #include "llvm/ADT/StringRef.h"
-#include "llvm/Support/TimeValue.h"
+#include "llvm/Support/Chrono.h"
 #include <memory>
 #include <string>
 #include <vector>
@@ -51,7 +51,7 @@ public:
   void waitUntilDoneInitializing();
 
   bool isUnitOutOfDate(StringRef unitOutputPath, ArrayRef<StringRef> dirtyFiles);
-  bool isUnitOutOfDate(StringRef unitOutputPath, llvm::sys::TimeValue outOfDateModTime);
+  bool isUnitOutOfDate(StringRef unitOutputPath, llvm::sys::TimePoint<> outOfDateModTime);
 
   /// Check whether any unit(s) containing \p file are out of date and if so,
   /// *synchronously* notify the delegate.

--- a/include/IndexStoreDB/Index/IndexSystemDelegate.h
+++ b/include/IndexStoreDB/Index/IndexSystemDelegate.h
@@ -14,7 +14,7 @@
 #define INDEXSTOREDB_INDEX_INDEXSYSTEMDELEGATE_H
 
 #include "IndexStoreDB/Index/StoreUnitInfo.h"
-#include "llvm/Support/TimeValue.h"
+#include "llvm/Support/Chrono.h"
 #include <memory>
 #include <string>
 
@@ -75,7 +75,7 @@ public:
   virtual void processedStoreUnit(StoreUnitInfo unitInfo) {}
 
   virtual void unitIsOutOfDate(StoreUnitInfo unitInfo,
-                               llvm::sys::TimeValue outOfDateModTime,
+                               llvm::sys::TimePoint<> outOfDateModTime,
                                OutOfDateTriggerHintRef hint,
                                bool synchronous = false) {}
 

--- a/include/IndexStoreDB/Index/StoreUnitInfo.h
+++ b/include/IndexStoreDB/Index/StoreUnitInfo.h
@@ -14,7 +14,7 @@
 #define INDEXSTOREDB_INDEX_STOREUNITINFO_H
 
 #include "IndexStoreDB/Support/Path.h"
-#include "llvm/Support/TimeValue.h"
+#include "llvm/Support/Chrono.h"
 #include <string>
 
 namespace IndexStoreDB {
@@ -24,7 +24,7 @@ struct StoreUnitInfo {
   std::string UnitName;
   CanonicalFilePath MainFilePath;
   CanonicalFilePath OutFilePath;
-  llvm::sys::TimeValue ModTime;
+  llvm::sys::TimePoint<> ModTime;
 };
 
 } // namespace index

--- a/lib/Database/Database.cpp
+++ b/lib/Database/Database.cpp
@@ -32,7 +32,7 @@
 using namespace IndexStoreDB;
 using namespace IndexStoreDB::db;
 
-const unsigned Database::DATABASE_FORMAT_VERSION = 11;
+const unsigned Database::DATABASE_FORMAT_VERSION = 12;
 
 static const char *DeadProcessDBSuffix = "-dead";
 
@@ -237,7 +237,7 @@ UnitInfo Database::Implementation::getUnitInfo(IDCode unitCode, lmdb::txn &Txn) 
   ptr += sizeof(UnitInfo::Provider)*providerDepends.size();
   unitName = StringRef(ptr, infoData.NameLength);
 
-  llvm::sys::TimeValue modTime(infoData.Seconds, infoData.Nanoseconds);
+  llvm::sys::TimePoint<> modTime = llvm::sys::TimePoint<>(std::chrono::nanoseconds(infoData.NanoTime));
   return UnitInfo{ unitName, unitCode, modTime,
     infoData.OutFileCode, infoData.MainFileCode, infoData.SysrootCode, infoData.TargetCode,
     infoData.HasMainFile, infoData.HasSysroot, infoData.IsSystem,

--- a/lib/Database/DatabaseImpl.h
+++ b/lib/Database/DatabaseImpl.h
@@ -111,8 +111,7 @@ struct TimestampedFileForProviderData {
   IDCode FileCode;
   IDCode UnitCode;
   IDCode ModuleNameCode;
-  int64_t Seconds;
-  int32_t Nanoseconds;
+  uint64_t NanoTime;
   bool IsSystem;
 };
 
@@ -132,8 +131,7 @@ struct UnitInfoData {
   IDCode OutFileCode;
   IDCode SysrootCode;
   IDCode TargetCode;
-  int64_t Seconds;
-  int32_t Nanoseconds;
+  int64_t NanoTime;
   uint16_t NameLength;
   uint8_t SymProviderKind;
   bool HasMainFile : 1;

--- a/lib/Database/ImportTransactionImpl.h
+++ b/lib/Database/ImportTransactionImpl.h
@@ -37,7 +37,7 @@ public:
   IDCode addTargetName(StringRef target);
   IDCode addModuleName(StringRef moduleName);
   /// If file is already associated, its timestamp is updated if \c modTime is more recent.
-  void addFileAssociationForProvider(IDCode provider, IDCode file, IDCode unit, llvm::sys::TimeValue modTime, IDCode module, bool isSystem);
+  void addFileAssociationForProvider(IDCode provider, IDCode file, IDCode unit, llvm::sys::TimePoint<> modTime, IDCode module, bool isSystem);
   /// \returns true if there is no remaining file reference, false otherwise.
   bool removeFileAssociationFromProvider(IDCode provider, IDCode file, IDCode unit);
 

--- a/lib/Database/ReadTransactionImpl.h
+++ b/lib/Database/ReadTransactionImpl.h
@@ -50,8 +50,8 @@ public:
   bool getProviderFileReferences(IDCode provider,
                                  llvm::function_ref<bool(TimestampedPath path)> receiver);
   bool getProviderFileCodeReferences(IDCode provider,
-                                     llvm::function_ref<bool(IDCode pathCode, IDCode unitCode, llvm::sys::TimeValue modTime, IDCode moduleNameCode, bool isSystem)> receiver);
-  bool foreachProviderAndFileCodeReference(llvm::function_ref<bool(IDCode provider, IDCode pathCode, IDCode unitCode, llvm::sys::TimeValue modTime, IDCode moduleNameCode, bool isSystem)> receiver);
+                                     llvm::function_ref<bool(IDCode pathCode, IDCode unitCode, llvm::sys::TimePoint<> modTime, IDCode moduleNameCode, bool isSystem)> receiver);
+  bool foreachProviderAndFileCodeReference(llvm::function_ref<bool(IDCode provider, IDCode pathCode, IDCode unitCode, llvm::sys::TimePoint<> modTime, IDCode moduleNameCode, bool isSystem)> receiver);
 
   bool foreachUSROfGlobalSymbolKind(SymbolKind symKind, llvm::function_ref<bool(ArrayRef<IDCode> usrCodes)> receiver);
   bool foreachUSROfGlobalSymbolKind(GlobalSymbolKind globalSymKind, function_ref<bool(ArrayRef<IDCode> usrCodes)> receiver);

--- a/lib/Index/IndexDatastore.h
+++ b/lib/Index/IndexDatastore.h
@@ -46,7 +46,7 @@ public:
   void waitUntilDoneInitializing();
 
   bool isUnitOutOfDate(StringRef unitOutputPath, ArrayRef<StringRef> dirtyFiles);
-  bool isUnitOutOfDate(StringRef unitOutputPath, llvm::sys::TimeValue outOfDateModTime);
+  bool isUnitOutOfDate(StringRef unitOutputPath, llvm::sys::TimePoint<> outOfDateModTime);
 
   /// Check whether any unit(s) containing \p file are out of date and if so,
   /// *synchronously* notify the delegate.

--- a/lib/Index/IndexSystem.cpp
+++ b/lib/Index/IndexSystem.cpp
@@ -77,7 +77,7 @@ private:
   }
 
   virtual void unitIsOutOfDate(StoreUnitInfo unitInfo,
-                               llvm::sys::TimeValue outOfDateModTime,
+                               llvm::sys::TimePoint<> outOfDateModTime,
                                OutOfDateTriggerHintRef hint,
                                bool synchronous) override {
     if (!Other)
@@ -116,7 +116,7 @@ public:
   void waitUntilDoneInitializing();
 
   bool isUnitOutOfDate(StringRef unitOutputPath, ArrayRef<StringRef> dirtyFiles);
-  bool isUnitOutOfDate(StringRef unitOutputPath, llvm::sys::TimeValue outOfDateModTime);
+  bool isUnitOutOfDate(StringRef unitOutputPath, llvm::sys::TimePoint<> outOfDateModTime);
   void checkUnitContainingFileIsOutOfDate(StringRef file);
 
   void registerMainFiles(ArrayRef<StringRef> filePaths, StringRef productName);
@@ -233,7 +233,7 @@ bool IndexSystemImpl::isUnitOutOfDate(StringRef unitOutputPath, ArrayRef<StringR
   return IndexStore->isUnitOutOfDate(unitOutputPath, dirtyFiles);
 }
 
-bool IndexSystemImpl::isUnitOutOfDate(StringRef unitOutputPath, llvm::sys::TimeValue outOfDateModTime) {
+bool IndexSystemImpl::isUnitOutOfDate(StringRef unitOutputPath, llvm::sys::TimePoint<> outOfDateModTime) {
   return IndexStore->isUnitOutOfDate(unitOutputPath, outOfDateModTime);
 }
 
@@ -577,7 +577,7 @@ bool IndexSystem::isUnitOutOfDate(StringRef unitOutputPath, ArrayRef<StringRef> 
   return IMPL->isUnitOutOfDate(unitOutputPath, dirtyFiles);
 }
 
-bool IndexSystem::isUnitOutOfDate(StringRef unitOutputPath, llvm::sys::TimeValue outOfDateModTime) {
+bool IndexSystem::isUnitOutOfDate(StringRef unitOutputPath, llvm::sys::TimePoint<> outOfDateModTime) {
   return IMPL->isUnitOutOfDate(unitOutputPath, outOfDateModTime);
 }
 


### PR DESCRIPTION
The latest version of llvm no longer has TimeValue.h, so this replaces uses
with TimePoint and std::chrono.

I'd like to start porting this to Windows and as part of that, I need to pull in the Windows headers which means updating the llvm support libraries that are part of indexstore-db.