### PR TITLE
Remove LLVM_EXPORT references

### DIFF
--- a/include/IndexStoreDB/Database/Database.h
+++ b/include/IndexStoreDB/Database/Database.h
@@ -15,6 +15,7 @@
 
 #include "IndexStoreDB/Database/IDCode.h"
 #include "IndexStoreDB/Support/LLVM.h"
+#include "IndexStoreDB/Support/Visibility.h"
 #include <memory>
 
 namespace IndexStoreDB {
@@ -22,7 +23,7 @@ namespace db {
   class Database;
   typedef std::shared_ptr<Database> DatabaseRef;
 
-class LLVM_EXPORT Database {
+class INDEXSTOREDB_EXPORT Database {
 public:
   static DatabaseRef create(StringRef dbPath, bool readonly, Optional<size_t> initialDBSize, std::string &error);
   ~Database();
@@ -43,7 +44,7 @@ public:
   static const unsigned DATABASE_FORMAT_VERSION;
 };
 
-LLVM_EXPORT IDCode makeIDCodeFromString(StringRef name);
+INDEXSTOREDB_EXPORT IDCode makeIDCodeFromString(StringRef name);
 
 } // namespace db
 } // namespace IndexStoreDB

--- a/include/IndexStoreDB/Database/DatabaseError.h
+++ b/include/IndexStoreDB/Database/DatabaseError.h
@@ -13,14 +13,14 @@
 #ifndef INDEXSTOREDB_SKDATABASE_DATABASEERROR_H
 #define INDEXSTOREDB_SKDATABASE_DATABASEERROR_H
 
-#include "llvm/Support/Compiler.h"
+#include "IndexStoreDB/Support/Visibility.h"
 #include <string>
 #include <stdexcept>
 
 namespace IndexStoreDB {
 namespace db {
 
-class LLVM_EXPORT DatabaseError : public std::runtime_error {
+class INDEXSTOREDB_EXPORT DatabaseError : public std::runtime_error {
 protected:
   const int _code;
 
@@ -51,7 +51,7 @@ public:
 ///
 /// @see http://symas.com/mdb/doc/group__errors.html#ga0a83370402a060c9175100d4bbfb9f25
 ///
-class LLVM_EXPORT MapFullError final : public DatabaseError {
+class INDEXSTOREDB_EXPORT MapFullError final : public DatabaseError {
   virtual void _anchor();
 public:
   using DatabaseError::DatabaseError;

--- a/include/IndexStoreDB/Database/ImportTransaction.h
+++ b/include/IndexStoreDB/Database/ImportTransaction.h
@@ -24,7 +24,7 @@ namespace db {
   class Database;
   typedef std::shared_ptr<Database> DatabaseRef;
 
-class LLVM_EXPORT ImportTransaction {
+class INDEXSTOREDB_EXPORT ImportTransaction {
 public:
   explicit ImportTransaction(DatabaseRef dbase);
   ~ImportTransaction();
@@ -48,7 +48,7 @@ private:
   std::unique_ptr<Implementation> Impl;
 };
 
-class LLVM_EXPORT UnitDataImport {
+class INDEXSTOREDB_EXPORT UnitDataImport {
   ImportTransaction &Import;
   std::string UnitName;
   CanonicalFilePath MainFile;

--- a/include/IndexStoreDB/Database/ReadTransaction.h
+++ b/include/IndexStoreDB/Database/ReadTransaction.h
@@ -26,7 +26,7 @@ namespace db {
   class Database;
   typedef std::shared_ptr<Database> DatabaseRef;
 
-class LLVM_EXPORT ReadTransaction {
+class INDEXSTOREDB_EXPORT ReadTransaction {
 public:
   explicit ReadTransaction(DatabaseRef dbase);
   ~ReadTransaction();

--- a/include/IndexStoreDB/Index/IndexStoreLibraryProvider.h
+++ b/include/IndexStoreDB/Index/IndexStoreLibraryProvider.h
@@ -14,6 +14,7 @@
 #define INDEXSTOREDB_INDEX_SYMBOLDATAPROVIDER_H
 
 #include "IndexStoreDB/Support/LLVM.h"
+#include "IndexStoreDB/Support/Visibility.h"
 #include "llvm/ADT/StringRef.h"
 #include <memory>
 
@@ -29,7 +30,7 @@ namespace index {
 using IndexStoreLibrary = ::indexstore::IndexStoreLibrary;
 using IndexStoreLibraryRef = ::indexstore::IndexStoreLibraryRef;
 
-class LLVM_EXPORT IndexStoreLibraryProvider {
+class INDEXSTOREDB_EXPORT IndexStoreLibraryProvider {
 public:
   virtual ~IndexStoreLibraryProvider() {}
 
@@ -41,12 +42,12 @@ private:
 };
 
 /// A simple library provider that can be used if libIndexStore is linked to your binary.
-class LLVM_EXPORT GlobalIndexStoreLibraryProvider: public IndexStoreLibraryProvider {
+class INDEXSTOREDB_EXPORT GlobalIndexStoreLibraryProvider: public IndexStoreLibraryProvider {
 public:
   IndexStoreLibraryRef getLibraryForStorePath(StringRef storePath) override;
 };
 
-LLVM_EXPORT IndexStoreLibraryRef loadIndexStoreLibrary(std::string dylibPath,
+INDEXSTOREDB_EXPORT IndexStoreLibraryRef loadIndexStoreLibrary(std::string dylibPath,
                                                        std::string &error);
 
 } // namespace index

--- a/include/IndexStoreDB/Index/IndexSystem.h
+++ b/include/IndexStoreDB/Index/IndexSystem.h
@@ -14,6 +14,7 @@
 #define INDEXSTOREDB_INDEX_INDEXSYSTEM_H
 
 #include "IndexStoreDB/Support/LLVM.h"
+#include "IndexStoreDB/Support/Visibility.h"
 #include "llvm/ADT/OptionSet.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/Chrono.h"
@@ -37,7 +38,7 @@ namespace index {
   struct StoreUnitInfo;
   class IndexStoreLibraryProvider;
 
-class LLVM_EXPORT IndexSystem {
+class INDEXSTOREDB_EXPORT IndexSystem {
 public:
   ~IndexSystem();
 

--- a/include/IndexStoreDB/Index/IndexSystemDelegate.h
+++ b/include/IndexStoreDB/Index/IndexSystemDelegate.h
@@ -65,7 +65,7 @@ public:
   virtual std::string description() override;
 };
 
-class LLVM_EXPORT IndexSystemDelegate {
+class INDEXSTOREDB_EXPORT IndexSystemDelegate {
 public:
   virtual ~IndexSystemDelegate() {}
 

--- a/include/IndexStoreDB/Support/Concurrency.h
+++ b/include/IndexStoreDB/Support/Concurrency.h
@@ -13,11 +13,12 @@
 #ifndef LLVM_INDEXSTOREDB_SUPPORT_CONCURRENCY_H
 #define LLVM_INDEXSTOREDB_SUPPORT_CONCURRENCY_H
 
+#include "IndexStoreDB/Support/Visibility.h"
 #include "llvm/ADT/StringRef.h"
 
 namespace IndexStoreDB {
 
-class LLVM_EXPORT WorkQueue {
+class INDEXSTOREDB_EXPORT WorkQueue {
 public:
   enum class Dequeuing {
     Serial,

--- a/include/IndexStoreDB/Support/FilePathWatcher.h
+++ b/include/IndexStoreDB/Support/FilePathWatcher.h
@@ -14,13 +14,14 @@
 #define INDEXSTOREDB_SUPPORT_FILEPATHWATCHER_H
 
 #include "IndexStoreDB/Support/LLVM.h"
+#include "IndexStoreDB/Support/Visibility.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/StringRef.h"
 #include <functional>
 
 namespace IndexStoreDB {
 
-class LLVM_EXPORT FilePathWatcher {
+class INDEXSTOREDB_EXPORT FilePathWatcher {
   struct Implementation;
 
 public:

--- a/include/IndexStoreDB/Support/Logging.h
+++ b/include/IndexStoreDB/Support/Logging.h
@@ -14,10 +14,10 @@
 #define LLVM_INDEXSTOREDB_SUPPORT_LOGGING_H
 
 #include "IndexStoreDB/Support/LLVM.h"
+#include "IndexStoreDB/Support/Visibility.h"
 #include "llvm/ADT/IntrusiveRefCntPtr.h"
 #include "llvm/ADT/SmallString.h"
 #include "llvm/ADT/StringRef.h"
-#include "llvm/Support/Compiler.h"
 #include "llvm/Support/raw_ostream.h"
 #include "llvm/Support/Timer.h"
 #include <string>
@@ -29,7 +29,7 @@ class format_object_base;
 namespace IndexStoreDB {
   class Logger;
 
-LLVM_EXPORT void writeEscaped(StringRef Str, raw_ostream &OS);
+INDEXSTOREDB_EXPORT void writeEscaped(StringRef Str, raw_ostream &OS);
 
 typedef IntrusiveRefCntPtr<Logger> LogRef;
 
@@ -40,7 +40,7 @@ typedef IntrusiveRefCntPtr<Logger> LogRef;
 ///     *Log << "stuff";
 ///   }
 /// \endcode
-class LLVM_EXPORT Logger : public llvm::ThreadSafeRefCountedBase<Logger> {
+class INDEXSTOREDB_EXPORT Logger : public llvm::ThreadSafeRefCountedBase<Logger> {
 public:
   enum class Level : unsigned char {
     /// \brief No logging.

--- a/include/IndexStoreDB/Support/Path.h
+++ b/include/IndexStoreDB/Support/Path.h
@@ -14,6 +14,7 @@
 #define INDEXSTOREDB_SUPPORT_PATH_H
 
 #include "IndexStoreDB/Support/LLVM.h"
+#include "IndexStoreDB/Support/Visibility.h"
 #include "llvm/ADT/SmallString.h"
 #include "llvm/Support/Path.h"
 
@@ -77,7 +78,7 @@ public:
 inline CanonicalFilePath::CanonicalFilePath(CanonicalFilePathRef CanonPath)
   : Path(CanonPath.getPath()) {}
 
-class LLVM_EXPORT CanonicalPathCache {
+class INDEXSTOREDB_EXPORT CanonicalPathCache {
   void *Impl;
 
 public:

--- a/include/IndexStoreDB/Support/PatternMatching.h
+++ b/include/IndexStoreDB/Support/PatternMatching.h
@@ -14,10 +14,11 @@
 #define INDEXSTOREDB_SUPPORT_PATTERNMATCHING_H
 
 #include "IndexStoreDB/Support/LLVM.h"
+#include "IndexStoreDB/Support/Visibility.h"
 
 namespace IndexStoreDB {
 
-LLVM_EXPORT
+INDEXSTOREDB_EXPORT
 bool matchesPattern(StringRef Input,
                     StringRef Pattern,
                     bool AnchorStart,

--- a/include/IndexStoreDB/Support/Visibility.h
+++ b/include/IndexStoreDB/Support/Visibility.h
@@ -1,0 +1,26 @@
+//===--- Visibility.h ------------------------------------------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_INDEXSTOREDB_SUPPORT_VISIBILITY_H
+#define LLVM_INDEXSTOREDB_SUPPORT_VISIBILITY_H
+
+#ifndef __has_attribute
+#define __has_attribute(x) 0
+#endif
+
+#if __has_attribute(visibility)
+#define INDEXSTOREDB_EXPORT __attribute__ ((visibility("default")))
+#else
+#define INDEXSTOREDB_EXPORT
+#endif
+
+#endif


### PR DESCRIPTION
LLVM_EXPORT no longer exists in llvm, remove it in preparation to pull in a new version