### PR TITLE
[Index] Introduce IndexSystem::foreachUnitTestSymbolReferencedByOutputPaths()

### DIFF
--- a/include/IndexStoreDB/Database/ReadTransaction.h
+++ b/include/IndexStoreDB/Database/ReadTransaction.h
@@ -53,6 +53,9 @@ public:
   bool foreachUSROfGlobalSymbolKind(SymbolKind symKind, llvm::function_ref<bool(ArrayRef<IDCode> usrCodes)> receiver);
 
   /// Returns USR codes in batches.
+  bool foreachUSROfGlobalUnitTestSymbol(llvm::function_ref<bool(ArrayRef<IDCode> usrCodes)> receiver);
+
+  /// Returns USR codes in batches.
   bool findUSRsWithNameContaining(StringRef pattern,
                                   bool anchorStart, bool anchorEnd,
                                   bool subsequence, bool ignoreCase,

--- a/include/IndexStoreDB/Index/IndexSystem.h
+++ b/include/IndexStoreDB/Index/IndexSystem.h
@@ -124,6 +124,11 @@ public:
   bool foreachFileIncludedByFile(StringRef SourcePath,
                                               function_ref<bool(CanonicalFilePathRef TargetPath, unsigned Line)> Receiver);
 
+  /// Returns unit test class/method occurrences that are referenced from units associated with the provided output file paths.
+  /// \returns `false` if the receiver returned `false` to stop receiving symbols, `true` otherwise.
+  bool foreachUnitTestSymbolReferencedByOutputPaths(ArrayRef<StringRef> FilePaths,
+      function_ref<bool(SymbolOccurrenceRef Occur)> Receiver);
+
 private:
   IndexSystem(void *Impl) : Impl(Impl) {}
 

--- a/include/IndexStoreDB/Index/SymbolDataProvider.h
+++ b/include/IndexStoreDB/Index/SymbolDataProvider.h
@@ -56,6 +56,9 @@ public:
                                             SymbolRoleSet RoleSet,
                         function_ref<bool(SymbolOccurrenceRef Occur)> Receiver) = 0;
 
+  virtual bool foreachUnitTestSymbolOccurrence(
+                        function_ref<bool(SymbolOccurrenceRef Occur)> Receiver) = 0;
+
 private:
   virtual void anchor();
 };

--- a/include/IndexStoreDB/Index/SymbolIndex.h
+++ b/include/IndexStoreDB/Index/SymbolIndex.h
@@ -83,6 +83,9 @@ public:
   bool foreachCanonicalSymbolOccurrenceByKind(SymbolKind symKind, bool workspaceOnly,
                                               function_ref<bool(SymbolOccurrenceRef Occur)> Receiver);
 
+  bool foreachUnitTestSymbolReferencedByOutputPaths(ArrayRef<CanonicalFilePath> FilePaths,
+      function_ref<bool(SymbolOccurrenceRef Occur)> Receiver);
+
 private:
   void *Impl; // A SymbolIndexImpl.
 };

--- a/lib/Database/ReadTransaction.cpp
+++ b/lib/Database/ReadTransaction.cpp
@@ -248,6 +248,14 @@ bool ReadTransaction::Implementation::foreachUSROfGlobalSymbolKind(SymbolKind sy
   return foreachUSROfGlobalSymbolKind(globalKindOpt.getValue(), receiver);
 }
 
+bool ReadTransaction::Implementation::foreachUSROfGlobalUnitTestSymbol(function_ref<bool(ArrayRef<IDCode> usrCodes)> receiver) {
+  bool cont = foreachUSROfGlobalSymbolKind(GlobalSymbolKind::TestClassOrExtension, receiver);
+  if (cont) {
+    cont = foreachUSROfGlobalSymbolKind(GlobalSymbolKind::TestMethod, receiver);
+  }
+  return cont;
+}
+
 bool ReadTransaction::Implementation::foreachUSROfGlobalSymbolKind(GlobalSymbolKind globalKind,
                                                                    function_ref<bool(ArrayRef<IDCode> usrCodes)> receiver) {
   auto &db = DBase->impl();
@@ -637,6 +645,10 @@ bool ReadTransaction::foreachProviderAndFileCodeReference(llvm::function_ref<boo
 
 bool ReadTransaction::foreachUSROfGlobalSymbolKind(SymbolKind symKind, llvm::function_ref<bool(ArrayRef<IDCode> usrCodes)> receiver) {
   return Impl->foreachUSROfGlobalSymbolKind(symKind, std::move(receiver));
+}
+
+bool ReadTransaction::foreachUSROfGlobalUnitTestSymbol(llvm::function_ref<bool(ArrayRef<IDCode> usrCodes)> receiver) {
+  return Impl->foreachUSROfGlobalUnitTestSymbol(std::move(receiver));
 }
 
 bool ReadTransaction::findUSRsWithNameContaining(StringRef pattern,

--- a/lib/Database/ReadTransactionImpl.h
+++ b/lib/Database/ReadTransactionImpl.h
@@ -54,6 +54,7 @@ public:
   bool foreachProviderAndFileCodeReference(llvm::function_ref<bool(IDCode provider, IDCode pathCode, IDCode unitCode, llvm::sys::TimePoint<> modTime, IDCode moduleNameCode, bool isSystem)> receiver);
 
   bool foreachUSROfGlobalSymbolKind(SymbolKind symKind, llvm::function_ref<bool(ArrayRef<IDCode> usrCodes)> receiver);
+  bool foreachUSROfGlobalUnitTestSymbol(llvm::function_ref<bool(ArrayRef<IDCode> usrCodes)> receiver);
   bool foreachUSROfGlobalSymbolKind(GlobalSymbolKind globalSymKind, function_ref<bool(ArrayRef<IDCode> usrCodes)> receiver);
 
   bool findUSRsWithNameContaining(StringRef pattern,

--- a/lib/Index/IndexSystem.cpp
+++ b/lib/Index/IndexSystem.cpp
@@ -179,6 +179,9 @@ public:
 
   bool foreachFileIncludedByFile(StringRef SourcePath,
                                  function_ref<bool(CanonicalFilePathRef TargetPath, unsigned Line)> Receiver);
+
+  bool foreachUnitTestSymbolReferencedByOutputPaths(ArrayRef<StringRef> FilePaths,
+      function_ref<bool(SymbolOccurrenceRef Occur)> Receiver);
 };
 
 } // anonymous namespace
@@ -519,6 +522,15 @@ bool IndexSystemImpl::foreachFileIncludedByFile(StringRef SourcePath,
   return PathIndex->foreachFileIncludedByFile(canonSourcePath, Receiver);
 }
 
+bool IndexSystemImpl::foreachUnitTestSymbolReferencedByOutputPaths(ArrayRef<StringRef> FilePaths, function_ref<bool(SymbolOccurrenceRef Occur)> Receiver) {
+  SmallVector<CanonicalFilePath, 8> canonPaths;
+  canonPaths.reserve(FilePaths.size());
+  for (StringRef path : FilePaths) {
+    canonPaths.push_back(PathIndex->getCanonicalPath(path));
+  }
+  return SymIndex->foreachUnitTestSymbolReferencedByOutputPaths(canonPaths, std::move(Receiver));
+}
+
 //===----------------------------------------------------------------------===//
 // IndexSystem
 //===----------------------------------------------------------------------===//
@@ -695,4 +707,9 @@ bool IndexSystem::foreachFileIncludingFile(StringRef TargetPath,
 bool IndexSystem::foreachFileIncludedByFile(StringRef SourcePath,
                                                 function_ref<bool(CanonicalFilePathRef TargetPath, unsigned Line)> Receiver) {
   return IMPL->foreachFileIncludedByFile(SourcePath, Receiver);
+}
+
+bool IndexSystem::foreachUnitTestSymbolReferencedByOutputPaths(ArrayRef<StringRef> FilePaths,
+    function_ref<bool(SymbolOccurrenceRef Occur)> Receiver) {
+  return IMPL->foreachUnitTestSymbolReferencedByOutputPaths(FilePaths, std::move(Receiver));
 }

--- a/lib/Index/StoreSymbolRecord.h
+++ b/lib/Index/StoreSymbolRecord.h
@@ -82,6 +82,10 @@ public:
   virtual bool foreachRelatedSymbolOccurrenceByUSR(ArrayRef<db::IDCode> USRs,
                                             SymbolRoleSet RoleSet,
                function_ref<bool(SymbolOccurrenceRef Occur)> Receiver) override;
+
+  virtual bool foreachUnitTestSymbolOccurrence(
+               function_ref<bool(SymbolOccurrenceRef Occur)> Receiver) override;
+
 };
 
 } // namespace index

--- a/lib/Index/SymbolIndex.cpp
+++ b/lib/Index/SymbolIndex.cpp
@@ -78,6 +78,8 @@ public:
   size_t countOfCanonicalSymbolsWithKind(SymbolKind symKind, bool workspaceOnly);
   bool foreachCanonicalSymbolOccurrenceByKind(SymbolKind symKind, bool workspaceOnly,
                                               function_ref<bool(SymbolOccurrenceRef Occur)> Receiver);
+  bool foreachUnitTestSymbolReferencedByOutputPaths(ArrayRef<CanonicalFilePath> FilePaths,
+      function_ref<bool(SymbolOccurrenceRef Occur)> Receiver);
 
 private:
   bool foreachCanonicalSymbolImpl(bool workspaceOnly,
@@ -88,7 +90,8 @@ private:
                                             function_ref<bool(SymbolOccurrenceRef)> Receiver);
   std::vector<SymbolDataProviderRef> lookupProvidersForUSR(StringRef USR, SymbolRoleSet roles, SymbolRoleSet relatedRoles);
   std::vector<std::pair<SymbolDataProviderRef, bool>> findCanonicalProvidersForUSR(IDCode usrCode);
-  SymbolDataProviderRef createProviderForCode(IDCode providerCode, ReadTransaction &reader);
+  SymbolDataProviderRef createVisibleProviderForCode(IDCode providerCode, ReadTransaction &reader);
+  SymbolDataProviderRef createProviderForCode(IDCode providerCode, ReadTransaction &reader, function_ref<bool(ReadTransaction &, const UnitInfo &)> unitFilter);
 };
 
 } // anonymous namespace
@@ -162,7 +165,13 @@ void SymbolIndexImpl::dumpProviderFileAssociations(raw_ostream &OS) {
   });
 }
 
-SymbolDataProviderRef SymbolIndexImpl::createProviderForCode(IDCode providerCode, ReadTransaction &reader) {
+SymbolDataProviderRef SymbolIndexImpl::createVisibleProviderForCode(IDCode providerCode, ReadTransaction &reader) {
+  return createProviderForCode(providerCode, reader, [&](ReadTransaction &reader, const UnitInfo &unitInfo) -> bool {
+    return VisibilityChecker->isUnitVisible(unitInfo, reader);
+  });
+}
+
+SymbolDataProviderRef SymbolIndexImpl::createProviderForCode(IDCode providerCode, ReadTransaction &reader, function_ref<bool(ReadTransaction &, const UnitInfo &)> unitFilter) {
   StringRef recordName = reader.getProviderName(providerCode);
   if (recordName.empty()) {
     ++NumMissingProvidersLookedUp;
@@ -175,7 +184,7 @@ SymbolDataProviderRef SymbolIndexImpl::createProviderForCode(IDCode providerCode
     auto unitInfo = reader.getUnitInfo(unitCode);
     if (unitInfo.isInvalid())
       return true;
-    if (!VisibilityChecker->isUnitVisible(unitInfo, reader))
+    if (!unitFilter(reader, unitInfo))
       return true;
 
     if (!providerKind.hasValue()) {
@@ -206,7 +215,7 @@ SymbolIndexImpl::lookupProvidersForUSR(StringRef USR, SymbolRoleSet roles, Symbo
   std::vector<SymbolDataProviderRef> providers;
   ReadTransaction reader(DBase);
   reader.lookupProvidersForUSR(USR, roles, relatedRoles, [&](IDCode providerCode, SymbolRoleSet roles, SymbolRoleSet relatedRoles) -> bool {
-    if (auto prov = createProviderForCode(providerCode, reader))
+    if (auto prov = createVisibleProviderForCode(providerCode, reader))
       providers.push_back(prov);
     return true;
   });
@@ -279,7 +288,7 @@ bool SymbolIndexImpl::foreachCanonicalSymbolImpl(bool workspaceOnly,
           if (provInfo.IsInvisible)
             return provInfo;
           if (!provInfo.Provider) {
-            provInfo.Provider = createProviderForCode(provCode, reader);
+            provInfo.Provider = createVisibleProviderForCode(provCode, reader);
             if (!provInfo.Provider)
               provInfo.IsInvisible = true;
           }
@@ -442,11 +451,52 @@ SymbolIndexImpl::findCanonicalProvidersForUSR(IDCode usrCode) {
     bool isCanon = provCodeAndHasDef.second;
     if (!isCanon && foundCanon)
       break;
-    if (auto prov = createProviderForCode(provCode, reader))
+    if (auto prov = createVisibleProviderForCode(provCode, reader))
       foundProvs.emplace_back(std::move(prov), isCanon);
     foundCanon |= isCanon;
   }
   return foundProvs;
+}
+
+bool SymbolIndexImpl::foreachUnitTestSymbolReferencedByOutputPaths(ArrayRef<CanonicalFilePath> outFilePaths, function_ref<bool(SymbolOccurrenceRef Occur)> receiver) {
+  std::vector<SymbolDataProviderRef> providers;
+  {
+    ReadTransaction reader(DBase);
+
+    std::unordered_set<IDCode> providerCodes;
+    reader.foreachUSROfGlobalUnitTestSymbol([&](ArrayRef<IDCode> usrCodes) -> bool {
+      for (IDCode usrCode : usrCodes) {
+        reader.lookupProvidersForUSR(usrCode, None, None, [&](IDCode providerCode, SymbolRoleSet roles, SymbolRoleSet relatedRoles) -> bool {
+          providerCodes.insert(providerCode);
+          return true;
+        });
+      }
+      return true;
+    });
+
+    if (providerCodes.empty()) {
+      return true;
+    }
+
+    std::unordered_set<IDCode> outFileCodes;
+    for (const CanonicalFilePath &path : outFilePaths) {
+      outFileCodes.insert(reader.getFilePathCode(path));
+    }
+    for (IDCode providerCode : providerCodes) {
+      auto provider = createProviderForCode(providerCode, reader, [&](ReadTransaction &reader, const UnitInfo &unitInfo) -> bool {
+        return outFileCodes.count(unitInfo.OutFileCode);
+      });
+      if (provider) {
+        providers.push_back(std::move(provider));
+      }
+    }
+  }
+
+  for (SymbolDataProviderRef provider : providers) {
+    bool cont = provider->foreachUnitTestSymbolOccurrence(receiver);
+    if (!cont) return false;
+  }
+  return true;
 }
 
 //===----------------------------------------------------------------------===//
@@ -526,4 +576,9 @@ size_t SymbolIndex::countOfCanonicalSymbolsWithKind(SymbolKind symKind, bool wor
 bool SymbolIndex::foreachCanonicalSymbolOccurrenceByKind(SymbolKind symKind, bool workspaceOnly,
                                                          function_ref<bool(SymbolOccurrenceRef Occur)> Receiver) {
   return IMPL->foreachCanonicalSymbolOccurrenceByKind(symKind, workspaceOnly, std::move(Receiver));
+}
+
+bool SymbolIndex::foreachUnitTestSymbolReferencedByOutputPaths(ArrayRef<CanonicalFilePath> FilePaths,
+    function_ref<bool(SymbolOccurrenceRef Occur)> Receiver) {
+  return IMPL->foreachUnitTestSymbolReferencedByOutputPaths(FilePaths, std::move(Receiver));
 }


### PR DESCRIPTION
This is useful for retrieving all the unit test class/method occurrences that are referenced from a set of output file paths and their associated units.