### PR TITLE
Keep track and report the unit files that contain test symbols

### DIFF
--- a/include/IndexStoreDB/Database/ImportTransaction.h
+++ b/include/IndexStoreDB/Database/ImportTransaction.h
@@ -31,6 +31,9 @@ public:
 
   IDCode getUnitCode(StringRef unitName);
   IDCode addProviderName(StringRef name, bool *wasInserted = nullptr);
+  // Marks a provider as containing test symbols.
+  void setProviderContainsTestSymbols(IDCode provider);
+  bool providerContainsTestSymbols(IDCode provider);
   /// \returns a IDCode of the USR.
   IDCode addSymbolInfo(IDCode provider,
                        StringRef USR, StringRef symbolName, SymbolInfo symInfo,
@@ -56,6 +59,7 @@ class INDEXSTOREDB_EXPORT UnitDataImport {
   CanonicalFilePath Sysroot;
   llvm::sys::TimePoint<> ModTime;
   Optional<bool> IsSystem;
+  Optional<bool> HasTestSymbols;
   Optional<SymbolProviderKind> SymProviderKind;
   std::string Target;
 
@@ -83,6 +87,7 @@ public:
   bool isMissing() const { return IsMissing; }
   bool isUpToDate() const { return IsUpToDate; }
   Optional<bool> getIsSystem() const { return IsSystem; }
+  Optional<bool> getHasTestSymbols() const { return HasTestSymbols; }
   Optional<SymbolProviderKind> getSymbolProviderKind() const { return SymProviderKind; }
 
   IDCode getPrevMainFileCode() const {

--- a/include/IndexStoreDB/Database/ReadTransaction.h
+++ b/include/IndexStoreDB/Database/ReadTransaction.h
@@ -53,6 +53,8 @@ public:
   bool foreachProviderAndFileCodeReference(function_ref<bool(IDCode unitCode)> unitFilter,
     function_ref<bool(IDCode provider, IDCode pathCode, IDCode unitCode, llvm::sys::TimePoint<> modTime, IDCode moduleNameCode, bool isSystem)> receiver);
 
+  bool foreachProviderContainingTestSymbols(function_ref<bool(IDCode provider)> receiver);
+
   /// Returns USR codes in batches.
   bool foreachUSROfGlobalSymbolKind(SymbolKind symKind, llvm::function_ref<bool(ArrayRef<IDCode> usrCodes)> receiver);
 

--- a/include/IndexStoreDB/Database/UnitInfo.h
+++ b/include/IndexStoreDB/Database/UnitInfo.h
@@ -46,6 +46,7 @@ struct UnitInfo {
   bool HasMainFile;
   bool HasSysroot;
   bool IsSystem;
+  bool HasTestSymbols;
   SymbolProviderKind SymProviderKind;
   ArrayRef<IDCode> FileDepends;
   ArrayRef<IDCode> UnitDepends;

--- a/include/IndexStoreDB/Index/IndexSystem.h
+++ b/include/IndexStoreDB/Index/IndexSystem.h
@@ -126,7 +126,7 @@ public:
 
   /// Returns unit test class/method occurrences that are referenced from units associated with the provided output file paths.
   /// \returns `false` if the receiver returned `false` to stop receiving symbols, `true` otherwise.
-  bool foreachUnitTestSymbolReferencedByOutputPaths(ArrayRef<StringRef> FilePaths,
+  bool foreachUnitTestSymbolReferencedByOutputPaths(ArrayRef<CanonicalFilePathRef> FilePaths,
       function_ref<bool(SymbolOccurrenceRef Occur)> Receiver);
 
 private:

--- a/include/IndexStoreDB/Index/StoreUnitInfo.h
+++ b/include/IndexStoreDB/Index/StoreUnitInfo.h
@@ -24,7 +24,18 @@ struct StoreUnitInfo {
   std::string UnitName;
   CanonicalFilePath MainFilePath;
   CanonicalFilePath OutFilePath;
+  bool HasTestSymbols = false;
   llvm::sys::TimePoint<> ModTime;
+
+  StoreUnitInfo() = default;
+  StoreUnitInfo(std::string unitName, CanonicalFilePath mainFilePath,
+                CanonicalFilePath outFilePath, bool hasTestSymbols,
+                llvm::sys::TimePoint<> modTime)
+      : UnitName(unitName),
+        MainFilePath(mainFilePath),
+        OutFilePath(outFilePath),
+        HasTestSymbols(hasTestSymbols),
+        ModTime(modTime) {}
 };
 
 } // namespace index

--- a/include/IndexStoreDB/Index/SymbolIndex.h
+++ b/include/IndexStoreDB/Index/SymbolIndex.h
@@ -83,7 +83,7 @@ public:
   bool foreachCanonicalSymbolOccurrenceByKind(SymbolKind symKind, bool workspaceOnly,
                                               function_ref<bool(SymbolOccurrenceRef Occur)> Receiver);
 
-  bool foreachUnitTestSymbolReferencedByOutputPaths(ArrayRef<CanonicalFilePath> FilePaths,
+  bool foreachUnitTestSymbolReferencedByOutputPaths(ArrayRef<CanonicalFilePathRef> FilePaths,
       function_ref<bool(SymbolOccurrenceRef Occur)> Receiver);
 
 private:

--- a/lib/Database/Database.cpp
+++ b/lib/Database/Database.cpp
@@ -32,7 +32,7 @@
 using namespace IndexStoreDB;
 using namespace IndexStoreDB::db;
 
-const unsigned Database::DATABASE_FORMAT_VERSION = 12;
+const unsigned Database::DATABASE_FORMAT_VERSION = 13;
 
 static const char *DeadProcessDBSuffix = "-dead";
 
@@ -144,7 +144,7 @@ retry:
     db->SavedPath = savedPathBuf.str();
     db->ProcessPath = processPathBuf.str();
     db->DBEnv = lmdb::env::create();
-    db->DBEnv.set_max_dbs(13);
+    db->DBEnv.set_max_dbs(14);
 
     // Start with 64MB. We'll update with the actual size after we open the database.
     db->MapSize = initialDBSize.getValueOr(64ULL*1024ULL*1024ULL);
@@ -168,6 +168,7 @@ retry:
     db->DBISymbolProvidersByUSR = lmdb::dbi::open(txn, "usrs", MDB_INTEGERKEY|MDB_DUPSORT|MDB_DUPFIXED|MDB_CREATE);
     db->DBISymbolProvidersByUSR.set_dupsort(txn, providersForUSR_compare);
     db->DBISymbolProviderNameByCode = lmdb::dbi::open(txn, "providers", MDB_INTEGERKEY|MDB_CREATE);
+    db->DBISymbolProvidersWithTestSymbols = lmdb::dbi::open(txn, "providers-with-test-symbols", MDB_INTEGERKEY|MDB_CREATE);
     db->DBIUSRsBySymbolName = lmdb::dbi::open(txn, "symbol-names", MDB_DUPSORT|MDB_DUPFIXED|MDB_INTEGERDUP|MDB_CREATE);
     db->DBIUSRsByGlobalSymbolKind = lmdb::dbi::open(txn, "symbol-kinds", MDB_INTEGERKEY|MDB_DUPSORT|MDB_DUPFIXED|MDB_INTEGERDUP|MDB_CREATE);
     db->DBIDirNameByCode = lmdb::dbi::open(txn, "directories", MDB_INTEGERKEY|MDB_CREATE);
@@ -240,7 +241,7 @@ UnitInfo Database::Implementation::getUnitInfo(IDCode unitCode, lmdb::txn &Txn) 
   llvm::sys::TimePoint<> modTime = llvm::sys::TimePoint<>(std::chrono::nanoseconds(infoData.NanoTime));
   return UnitInfo{ unitName, unitCode, modTime,
     infoData.OutFileCode, infoData.MainFileCode, infoData.SysrootCode, infoData.TargetCode,
-    infoData.HasMainFile, infoData.HasSysroot, infoData.IsSystem,
+    infoData.HasMainFile, infoData.HasSysroot, infoData.IsSystem, infoData.HasTestSymbols,
     SymbolProviderKind(infoData.SymProviderKind),
     fileDepends, unitDepends, providerDepends };
 }

--- a/lib/Database/DatabaseImpl.h
+++ b/lib/Database/DatabaseImpl.h
@@ -27,6 +27,7 @@ class Database::Implementation {
   lmdb::env DBEnv{nullptr};
   lmdb::dbi DBISymbolProvidersByUSR{0};
   lmdb::dbi DBISymbolProviderNameByCode{0};
+  lmdb::dbi DBISymbolProvidersWithTestSymbols{0};
   lmdb::dbi DBIUSRsBySymbolName{0};
   lmdb::dbi DBIUSRsByGlobalSymbolKind{0};
   lmdb::dbi DBIDirNameByCode{0};
@@ -59,6 +60,7 @@ public:
   lmdb::env &getDBEnv() { return DBEnv; }
   lmdb::dbi &getDBISymbolProvidersByUSR() { return DBISymbolProvidersByUSR; }
   lmdb::dbi &getDBISymbolProviderNameByCode() { return DBISymbolProviderNameByCode; }
+  lmdb::dbi &getDBISymbolProvidersWithTestSymbols() { return DBISymbolProvidersWithTestSymbols; }
   lmdb::dbi &getDBIUSRsBySymbolName() { return DBIUSRsBySymbolName; }
   lmdb::dbi &getDBIUSRsByGlobalSymbolKind() { return DBIUSRsByGlobalSymbolKind; }
   lmdb::dbi &getDBIDirNameByCode() { return DBIDirNameByCode; }
@@ -137,6 +139,7 @@ struct UnitInfoData {
   bool HasMainFile : 1;
   bool HasSysroot : 1;
   bool IsSystem : 1;
+  bool HasTestSymbols : 1;
   uint32_t FileDependSize;
   uint32_t UnitDependSize;
   uint32_t ProviderDependSize;

--- a/lib/Database/ImportTransactionImpl.h
+++ b/lib/Database/ImportTransactionImpl.h
@@ -29,6 +29,9 @@ public:
 
   IDCode getUnitCode(StringRef unitName);
   IDCode addProviderName(StringRef name, bool *wasInserted);
+  // Marks a provider as containing test symbols.
+  void setProviderContainsTestSymbols(IDCode provider);
+  bool providerContainsTestSymbols(IDCode provider);
   /// \returns a IDCode of the USR.
   IDCode addSymbolInfo(IDCode provider, StringRef USR, StringRef symbolName, SymbolInfo symInfo,
                        SymbolRoleSet roles, SymbolRoleSet relatedRoles);

--- a/lib/Database/ReadTransactionImpl.h
+++ b/lib/Database/ReadTransactionImpl.h
@@ -57,6 +57,8 @@ public:
   bool foreachProviderAndFileCodeReference(function_ref<bool(IDCode unitCode)> unitFilter,
     function_ref<bool(IDCode provider, IDCode pathCode, IDCode unitCode, llvm::sys::TimePoint<> modTime, IDCode moduleNameCode, bool isSystem)> receiver);
 
+  bool foreachProviderContainingTestSymbols(function_ref<bool(IDCode provider)> receiver);
+
   bool foreachUSROfGlobalSymbolKind(SymbolKind symKind, llvm::function_ref<bool(ArrayRef<IDCode> usrCodes)> receiver);
   bool foreachUSROfGlobalUnitTestSymbol(llvm::function_ref<bool(ArrayRef<IDCode> usrCodes)> receiver);
   bool foreachUSROfGlobalSymbolKind(GlobalSymbolKind globalSymKind, function_ref<bool(ArrayRef<IDCode> usrCodes)> receiver);

--- a/lib/Index/IndexSystem.cpp
+++ b/lib/Index/IndexSystem.cpp
@@ -180,7 +180,7 @@ public:
   bool foreachFileIncludedByFile(StringRef SourcePath,
                                  function_ref<bool(CanonicalFilePathRef TargetPath, unsigned Line)> Receiver);
 
-  bool foreachUnitTestSymbolReferencedByOutputPaths(ArrayRef<StringRef> FilePaths,
+  bool foreachUnitTestSymbolReferencedByOutputPaths(ArrayRef<CanonicalFilePathRef> FilePaths,
       function_ref<bool(SymbolOccurrenceRef Occur)> Receiver);
 };
 
@@ -522,13 +522,8 @@ bool IndexSystemImpl::foreachFileIncludedByFile(StringRef SourcePath,
   return PathIndex->foreachFileIncludedByFile(canonSourcePath, Receiver);
 }
 
-bool IndexSystemImpl::foreachUnitTestSymbolReferencedByOutputPaths(ArrayRef<StringRef> FilePaths, function_ref<bool(SymbolOccurrenceRef Occur)> Receiver) {
-  SmallVector<CanonicalFilePath, 8> canonPaths;
-  canonPaths.reserve(FilePaths.size());
-  for (StringRef path : FilePaths) {
-    canonPaths.push_back(PathIndex->getCanonicalPath(path));
-  }
-  return SymIndex->foreachUnitTestSymbolReferencedByOutputPaths(canonPaths, std::move(Receiver));
+bool IndexSystemImpl::foreachUnitTestSymbolReferencedByOutputPaths(ArrayRef<CanonicalFilePathRef> FilePaths, function_ref<bool(SymbolOccurrenceRef Occur)> Receiver) {
+  return SymIndex->foreachUnitTestSymbolReferencedByOutputPaths(FilePaths, std::move(Receiver));
 }
 
 //===----------------------------------------------------------------------===//
@@ -709,7 +704,7 @@ bool IndexSystem::foreachFileIncludedByFile(StringRef SourcePath,
   return IMPL->foreachFileIncludedByFile(SourcePath, Receiver);
 }
 
-bool IndexSystem::foreachUnitTestSymbolReferencedByOutputPaths(ArrayRef<StringRef> FilePaths,
+bool IndexSystem::foreachUnitTestSymbolReferencedByOutputPaths(ArrayRef<CanonicalFilePathRef> FilePaths,
     function_ref<bool(SymbolOccurrenceRef Occur)> Receiver) {
   return IMPL->foreachUnitTestSymbolReferencedByOutputPaths(FilePaths, std::move(Receiver));
 }


### PR DESCRIPTION
This allows the client to be much more efficient for handling unit test symbol changes.