### PR TITLE
Add ability to find symbols by name

### DIFF
--- a/Sources/IndexStoreDB/IndexStoreDB.swift
+++ b/Sources/IndexStoreDB/IndexStoreDB.swift
@@ -80,6 +80,33 @@ public final class IndexStoreDB {
       return body(SymbolOccurrence(occur))
     }
   }
+
+  public func foreachCanonicalSymbolOccurrenceByName(symbolName: String, body: @escaping (SymbolOccurrence) -> Bool) {
+    indexstoredb_for_each_canonical_symbol_occurence_by_name(impl, symbolName) { (occur) -> Bool in
+      body(SymbolOccurrence(occur))
+    }
+  }
+
+  public func findSymbols(matching query: String) -> [SymbolOccurrence] {
+    var symbolNameResults: [String] = []
+    indexstoredb_for_each_symbol_name(impl) { pointer in
+      let str = String(cString: pointer)
+      if str.range(of: query) != nil {
+        symbolNameResults.append(str)
+      }
+      return true
+    }
+    var symbolOccurenceResults: [SymbolOccurrence] = []
+    symbolNameResults.forEach { (symbolName) in
+      foreachCanonicalSymbolOccurrenceByName(symbolName: symbolName) {occurence in
+        if !occurence.location.isSystem {
+          symbolOccurenceResults.append(occurence)
+        }
+        return true
+      }
+    }
+    return symbolOccurenceResults
+  }
 }
 
 public struct SymbolRole: OptionSet {

--- a/Sources/IndexStoreDB/IndexStoreDB.swift
+++ b/Sources/IndexStoreDB/IndexStoreDB.swift
@@ -81,21 +81,21 @@ public final class IndexStoreDB {
     }
   }
 
-  public func forEachCanonicalSymbolOccurrenceByName(symbolName: String, body: @escaping (SymbolOccurrence) -> Bool) {
-    indexstoredb_for_each_canonical_symbol_occurence_by_name(impl, symbolName) { (occur) -> Bool in
-      body(SymbolOccurrence(occur))
+  @discardableResult public func forEachCanonicalSymbolOccurrence(byName: String, body: @escaping (SymbolOccurrence) -> Bool) -> Bool {
+    return indexstoredb_index_canonical_symbol_occurences_by_name(impl, byName) { occur in
+      return body(SymbolOccurrence(occur))
     }
   }
 
-  public func forEachCanonicalSymbolOccurrence(
+  @discardableResult public func forEachCanonicalSymbolOccurrence(
     containing pattern: String,
     anchorStart: Bool,
     anchorEnd: Bool,
     subsequence: Bool,
     ignoreCase: Bool,
     body: @escaping (SymbolOccurrence) -> Bool
-  ){
-    indexstoredb_for_each_canonical_symbol_occurence_containing_pattern(
+  ) -> Bool {
+    return indexstoredb_index_canonical_symbol_occurences_containing_pattern(
       impl,
       pattern,
       anchorStart,
@@ -107,22 +107,6 @@ public final class IndexStoreDB {
     }
   }
 
-  public func findSymbols(matching query: String) -> [SymbolOccurrence] {
-    var symbolOccurenceResults: [SymbolOccurrence] = []
-    forEachCanonicalSymbolOccurrence(
-      containing: query,
-      anchorStart: false,
-      anchorEnd: false,
-      subsequence: true,
-      ignoreCase: true
-    ) { (occurence) -> Bool in
-      if !occurence.location.isSystem {
-        symbolOccurenceResults.append(occurence)
-      }
-      return true
-    }
-    return symbolOccurenceResults
-  }
 }
 
 public struct SymbolRole: OptionSet {

--- a/include/CIndexStoreDB/CIndexStoreDB.h
+++ b/include/CIndexStoreDB/CIndexStoreDB.h
@@ -85,6 +85,9 @@ typedef _Nullable indexstoredb_indexstore_library_t(^indexstore_library_provider
 /// Returns true to continue.
 typedef bool(^indexstoredb_symbol_occurrence_receiver_t)(_Nonnull indexstoredb_symbol_occurrence_t);
 
+/// Returns true to continue.
+typedef bool(^indexstoredb_for_each_symbol_receiver)(const char *_Nonnull);
+
 INDEXSTOREDB_PUBLIC _Nullable
 indexstoredb_index_t
 indexstoredb_index_create(const char * _Nonnull storePath,
@@ -158,6 +161,16 @@ indexstoredb_error_get_description(_Nonnull indexstoredb_error_t);
 
 INDEXSTOREDB_PUBLIC void
 indexstoredb_error_dispose(_Nullable indexstoredb_error_t);
+
+INDEXSTOREDB_PUBLIC bool
+indexstoredb_for_each_symbol_name(_Nonnull indexstoredb_index_t index, _Nonnull indexstoredb_for_each_symbol_receiver);
+
+INDEXSTOREDB_PUBLIC bool
+indexstoredb_for_each_canonical_symbol_occurence_by_name(
+    indexstoredb_index_t _Nonnull index,
+    const char *_Nonnull symbolName,
+    indexstoredb_symbol_occurrence_receiver_t _Nonnull receiver
+);
 
 INDEXSTOREDB_END_DECLS
 

--- a/include/CIndexStoreDB/CIndexStoreDB.h
+++ b/include/CIndexStoreDB/CIndexStoreDB.h
@@ -162,26 +162,44 @@ indexstoredb_error_get_description(_Nonnull indexstoredb_error_t);
 INDEXSTOREDB_PUBLIC void
 indexstoredb_error_dispose(_Nullable indexstoredb_error_t);
 
+/// Loops through each symbol in the index and calls the receiver function with each symbol.
+/// @param index An IndexStoreDB object which contains the symbols.
+/// @param receiver A function to be called for each symbol, the CString of the symbol will be passed in to this function.
+/// The function should return a boolean indicating whether the looping should continue.
 INDEXSTOREDB_PUBLIC bool
-indexstoredb_for_each_symbol_name(_Nonnull indexstoredb_index_t index, _Nonnull indexstoredb_symbol_name_receiver);
+indexstoredb_index_symbol_names(_Nonnull indexstoredb_index_t index, _Nonnull indexstoredb_symbol_name_receiver);
 
+/// Loops through each canonical symbol that matches the string and performs the passed in function.
+/// @param index An IndexStoreDB object which contains the symbols.
+/// @param symbolName The name of the symbol whose canonical occurence should be found.
+/// @param receiver A function to be called for each canonical occurence.
+/// The SymbolOccurenceRef of the symbol will be passed in to this function.
+/// The function should return a boolean indicating whether the looping should continue.
 INDEXSTOREDB_PUBLIC bool
-indexstoredb_for_each_canonical_symbol_occurence_containing_pattern(
-    _Nonnull indexstoredb_index_t index,
-    const char *_Nonnull Pattern,
-    bool AnchorStart,
-    bool AnchorEnd,
-    bool Subsequence,
-    bool IgnoreCase,
-    _Nonnull indexstoredb_symbol_occurrence_receiver_t receiver);
-
-
-INDEXSTOREDB_PUBLIC bool
-indexstoredb_for_each_canonical_symbol_occurence_by_name(
+indexstoredb_index_canonical_symbol_occurences_by_name(
     indexstoredb_index_t _Nonnull index,
     const char *_Nonnull symbolName,
     indexstoredb_symbol_occurrence_receiver_t _Nonnull receiver
 );
+
+/// Loops through each canonical symbol that matches the pattern and performs the passed in function.
+/// @param index An IndexStoreDB object which contains the symbols.
+/// @param anchorStart When true, symbol names should only be considered matching when the first characters of the symbol name match the pattern.
+/// @param anchorEnd When true, symbol names should only be considered matching when the first characters of the symbol name match the pattern.
+/// @param subsequence When true, symbols will be matched even if the pattern is not matched contiguously.
+/// @param ignoreCase When true, symbols may be returned even if the case of letters does not match the pattern.
+/// @param receiver A function to be called for each canonical occurence that matches the pattern.
+/// The SymbolOccurenceRef of the symbol will be passed in to this function.
+/// The function should return a boolean indicating whether the looping should continue.
+INDEXSTOREDB_PUBLIC bool
+indexstoredb_index_canonical_symbol_occurences_containing_pattern(
+    _Nonnull indexstoredb_index_t index,
+    const char *_Nonnull pattern,
+    bool anchorStart,
+    bool anchorEnd,
+    bool subsequence,
+    bool ignoreCase,
+    _Nonnull indexstoredb_symbol_occurrence_receiver_t receiver);
 
 INDEXSTOREDB_END_DECLS
 

--- a/include/CIndexStoreDB/CIndexStoreDB.h
+++ b/include/CIndexStoreDB/CIndexStoreDB.h
@@ -86,7 +86,7 @@ typedef _Nullable indexstoredb_indexstore_library_t(^indexstore_library_provider
 typedef bool(^indexstoredb_symbol_occurrence_receiver_t)(_Nonnull indexstoredb_symbol_occurrence_t);
 
 /// Returns true to continue.
-typedef bool(^indexstoredb_for_each_symbol_receiver)(const char *_Nonnull);
+typedef bool(^indexstoredb_symbol_name_receiver)(const char *_Nonnull);
 
 INDEXSTOREDB_PUBLIC _Nullable
 indexstoredb_index_t
@@ -163,7 +163,18 @@ INDEXSTOREDB_PUBLIC void
 indexstoredb_error_dispose(_Nullable indexstoredb_error_t);
 
 INDEXSTOREDB_PUBLIC bool
-indexstoredb_for_each_symbol_name(_Nonnull indexstoredb_index_t index, _Nonnull indexstoredb_for_each_symbol_receiver);
+indexstoredb_for_each_symbol_name(_Nonnull indexstoredb_index_t index, _Nonnull indexstoredb_symbol_name_receiver);
+
+INDEXSTOREDB_PUBLIC bool
+indexstoredb_for_each_canonical_symbol_occurence_containing_pattern(
+    _Nonnull indexstoredb_index_t index,
+    const char *_Nonnull Pattern,
+    bool AnchorStart,
+    bool AnchorEnd,
+    bool Subsequence,
+    bool IgnoreCase,
+    _Nonnull indexstoredb_symbol_occurrence_receiver_t receiver);
+
 
 INDEXSTOREDB_PUBLIC bool
 indexstoredb_for_each_canonical_symbol_occurence_by_name(

--- a/lib/CIndexStoreDB/CIndexStoreDB.cpp
+++ b/lib/CIndexStoreDB/CIndexStoreDB.cpp
@@ -144,27 +144,16 @@ indexstoredb_symbol_name(indexstoredb_symbol_t symbol) {
   return obj->value->getName().c_str();
 }
 
-/// loops through each symbol in the index and calls the receiver function with each symbol
-/// @param index an IndexStoreDB object which contains the symbols
-/// @param receiver a function to be called for each symbol, the CString of the symbol will be passed in to this function.
-/// The function should return a boolean indicating whether the looping should continue.
 bool
-indexstoredb_for_each_symbol_name(indexstoredb_index_t index, indexstoredb_symbol_name_receiver receiver) {
-  // indexSystem has foreachsymbolName.
+indexstoredb_index_symbol_names(indexstoredb_index_t index, indexstoredb_symbol_name_receiver receiver) {
   auto obj = (IndexStoreDBObject<std::shared_ptr<IndexSystem>> *)index;
   return obj->value->foreachSymbolName([&](StringRef ref) -> bool {
     return receiver(ref.str().c_str());
   });
 }
 
-/// loops through each canonical symbol that matches the string, perform the passed in function
-/// @param index an IndexStoreDB object which contains the symbols
-/// @param symbolName the name of the symbol whose canonical occurence should be found
-/// @param receiver a function to be called for each canonical occurence, 
-/// the SymbolOccurenceRef of the symbol will be passed in to this function.
-/// The function should return a boolean indicating whether the looping should continue.
 bool
-indexstoredb_for_each_canonical_symbol_occurence_by_name(
+indexstoredb_index_canonical_symbol_occurences_by_name(
   indexstoredb_index_t index,
   const char *_Nonnull symbolName,
   indexstoredb_symbol_occurrence_receiver_t receiver)
@@ -175,32 +164,23 @@ indexstoredb_for_each_canonical_symbol_occurence_by_name(
   });
 }
 
-/// loops through each canonical symbol that matches the pattern, perform the passed in function
-/// @param index an IndexStoreDB object which contains the symbols.
-/// @param AnchorStart when true, symbol names should only be considered matching when the first characters of the symbol name match the pattern.
-/// @param AnchorEnd when true, symbol names should only be considered matching when the first characters of the symbol name match the pattern.
-/// @param Subsequence when true, symbols will be matched even if the pattern is not matched contiguously.
-/// @param IgnoreCase when true, symbols may be returned even if the case of letters does not match the pattern.
-/// @param receiver a function to be called for each canonical occurence that matches the pattern.
-/// The SymbolOccurenceRef of the symbol will be passed in to this function.
-/// The function should return a boolean indicating whether the looping should continue.
 bool
-indexstoredb_for_each_canonical_symbol_occurence_containing_pattern(
+indexstoredb_index_canonical_symbol_occurences_containing_pattern(
   indexstoredb_index_t index,
-  const char *_Nonnull Pattern,
-  bool AnchorStart,
-  bool AnchorEnd,
-  bool Subsequence,
-  bool IgnoreCase,
+  const char *_Nonnull pattern,
+  bool anchorStart,
+  bool anchorEnd,
+  bool subsequence,
+  bool ignoreCase,
   indexstoredb_symbol_occurrence_receiver_t receiver)
 {
   auto obj = (IndexStoreDBObject<std::shared_ptr<IndexSystem>> *)index;
   return obj->value->foreachCanonicalSymbolOccurrenceContainingPattern(
-    Pattern,
-    AnchorStart,
-    AnchorEnd,
-    Subsequence,
-    IgnoreCase,
+    pattern,
+    anchorStart,
+    anchorEnd,
+    subsequence,
+    ignoreCase,
     [&](SymbolOccurrenceRef occur
   ) -> bool {
       return receiver(make_object(occur));

--- a/lib/CIndexStoreDB/CIndexStoreDB.cpp
+++ b/lib/CIndexStoreDB/CIndexStoreDB.cpp
@@ -144,6 +144,37 @@ indexstoredb_symbol_name(indexstoredb_symbol_t symbol) {
   return obj->value->getName().c_str();
 }
 
+/// loops through each symbol in the index and calls the receiver function with each symbol
+/// @param index an IndexStoreDB object which contains the symbols
+/// @param receiver a function to be called for each symbol, the CString of the symbol will be passed in to this function.
+/// The function should return a boolean indicating whether the looping should continue.
+bool
+indexstoredb_for_each_symbol_name(indexstoredb_index_t index, indexstoredb_for_each_symbol_receiver receiver) {
+  // indexSystem has foreachsymbolName.
+  auto obj = (IndexStoreDBObject<std::shared_ptr<IndexSystem>> *)index;
+  return obj->value->foreachSymbolName([&](StringRef ref) -> bool {
+    return receiver(ref.str().c_str());
+  });
+}
+
+/// loops through each canonical symbol that matches the string, perform the passed in function
+/// @param index an IndexStoreDB object which contains the symbols
+/// @param symbolName the name of the symbol whose canonical occurence should be found
+/// @param receiver a function to be called for each canonical occurence, 
+/// the SymbolOccurenceRef of the symbol will be passed in to this function.
+/// The function should return a boolean indicating whether the looping should continue.
+bool
+indexstoredb_for_each_canonical_symbol_occurence_by_name(
+  indexstoredb_index_t index,
+  const char *_Nonnull symbolName,
+  indexstoredb_symbol_occurrence_receiver_t receiver)
+{
+  auto obj = (IndexStoreDBObject<std::shared_ptr<IndexSystem>> *)index;
+  return obj->value->foreachCanonicalSymbolOccurrenceByName(symbolName, [&](SymbolOccurrenceRef occur) -> bool {
+    return receiver(make_object(occur));
+  });
+}
+
 indexstoredb_symbol_t
 indexstoredb_symbol_occurrence_symbol(indexstoredb_symbol_occurrence_t occur) {
   auto obj = (IndexStoreDBObject<SymbolOccurrenceRef> *)occur;

--- a/lib/CIndexStoreDB/CIndexStoreDB.cpp
+++ b/lib/CIndexStoreDB/CIndexStoreDB.cpp
@@ -149,7 +149,7 @@ indexstoredb_symbol_name(indexstoredb_symbol_t symbol) {
 /// @param receiver a function to be called for each symbol, the CString of the symbol will be passed in to this function.
 /// The function should return a boolean indicating whether the looping should continue.
 bool
-indexstoredb_for_each_symbol_name(indexstoredb_index_t index, indexstoredb_for_each_symbol_receiver receiver) {
+indexstoredb_for_each_symbol_name(indexstoredb_index_t index, indexstoredb_symbol_name_receiver receiver) {
   // indexSystem has foreachsymbolName.
   auto obj = (IndexStoreDBObject<std::shared_ptr<IndexSystem>> *)index;
   return obj->value->foreachSymbolName([&](StringRef ref) -> bool {
@@ -172,6 +172,38 @@ indexstoredb_for_each_canonical_symbol_occurence_by_name(
   auto obj = (IndexStoreDBObject<std::shared_ptr<IndexSystem>> *)index;
   return obj->value->foreachCanonicalSymbolOccurrenceByName(symbolName, [&](SymbolOccurrenceRef occur) -> bool {
     return receiver(make_object(occur));
+  });
+}
+
+/// loops through each canonical symbol that matches the pattern, perform the passed in function
+/// @param index an IndexStoreDB object which contains the symbols.
+/// @param AnchorStart when true, symbol names should only be considered matching when the first characters of the symbol name match the pattern.
+/// @param AnchorEnd when true, symbol names should only be considered matching when the first characters of the symbol name match the pattern.
+/// @param Subsequence when true, symbols will be matched even if the pattern is not matched contiguously.
+/// @param IgnoreCase when true, symbols may be returned even if the case of letters does not match the pattern.
+/// @param receiver a function to be called for each canonical occurence that matches the pattern.
+/// The SymbolOccurenceRef of the symbol will be passed in to this function.
+/// The function should return a boolean indicating whether the looping should continue.
+bool
+indexstoredb_for_each_canonical_symbol_occurence_containing_pattern(
+  indexstoredb_index_t index,
+  const char *_Nonnull Pattern,
+  bool AnchorStart,
+  bool AnchorEnd,
+  bool Subsequence,
+  bool IgnoreCase,
+  indexstoredb_symbol_occurrence_receiver_t receiver)
+{
+  auto obj = (IndexStoreDBObject<std::shared_ptr<IndexSystem>> *)index;
+  return obj->value->foreachCanonicalSymbolOccurrenceContainingPattern(
+    Pattern,
+    AnchorStart,
+    AnchorEnd,
+    Subsequence,
+    IgnoreCase,
+    [&](SymbolOccurrenceRef occur
+  ) -> bool {
+      return receiver(make_object(occur));
   });
 }
 


### PR DESCRIPTION
This can be used in lsp projects to find
all symbols in a workspace that match a string.

https://bugs.swift.org/browse/SR-10806