### PR TITLE
[test] Add syntax for marking test location ending at comment

### DIFF
--- a/Tests/IndexStoreDBTests/LocationScannerTests.swift
+++ b/Tests/IndexStoreDBTests/LocationScannerTests.swift
@@ -127,6 +127,18 @@ final class LocationScannerTests: XCTestCase {
     ])
   }
 
+  func testLeft() throws {
+    XCTAssertEqual(try scanString("/*a*/"), [Loc("a", 1, 6)])
+    XCTAssertEqual(try scanString("/*<a*/"), [Loc("a", 1, 1)])
+
+    XCTAssertEqual(try scanString("/*a*/foo/*<a:end*/"), [
+      Loc("a", 1, 6),
+      Loc("a:end", 1, 9)
+    ])
+
+    XCTAssertThrowsError(try scanString("/*<a*//*a*/"))
+  }
+
   func testDirectory() throws {
     let proj1 = URL(fileURLWithPath: #file)
       .deletingLastPathComponent()

--- a/Tests/IndexStoreDBTests/XCTestManifests.swift
+++ b/Tests/IndexStoreDBTests/XCTestManifests.swift
@@ -29,6 +29,7 @@ extension LocationScannerTests {
     static let __allTests__LocationScannerTests = [
         ("testDirectory", testDirectory),
         ("testDuplicate", testDuplicate),
+        ("testLeft", testLeft),
         ("testLocation", testLocation),
         ("testMultiple", testMultiple),
         ("testName", testName),


### PR DESCRIPTION
Using a leading '<', we can now specify a location ending at the comment
instead of after it.  For example,

```swift
/*a:start*/abc/*<a:end*/
//         ^  ^
//   a:start  a:end

```

This is useful for forming source ranges.