### PR TITLE
[tibs] Add -sdk to swift compiles on macOS

### DIFF
--- a/Sources/ISDBTibs/TibsResolvedTarget.swift
+++ b/Sources/ISDBTibs/TibsResolvedTarget.swift
@@ -31,6 +31,7 @@ public final class TibsResolvedTarget {
     public var bridgingHeader: URL?
     public var moduleDeps: [String]
     public var importPaths: [String] { moduleDeps.isEmpty ? [] : ["."] }
+    public var sdk: String?
 
     public init(
       name: String,
@@ -40,7 +41,8 @@ public final class TibsResolvedTarget {
       emitHeaderPath: String? = nil,
       outputFileMap: OutputFileMap,
       bridgingHeader: URL? = nil,
-      moduleDeps: [String] = [])
+      moduleDeps: [String] = [],
+      sdk: String? = nil)
     {
       self.name = name
       self.extraArgs = extraArgs
@@ -50,6 +52,7 @@ public final class TibsResolvedTarget {
       self.outputFileMap = outputFileMap
       self.bridgingHeader = bridgingHeader
       self.moduleDeps = moduleDeps
+      self.sdk = sdk
     }
   }
 

--- a/Tests/ISDBTibsTests/TibsCompilationDatabaseTests.swift
+++ b/Tests/ISDBTibsTests/TibsCompilationDatabaseTests.swift
@@ -31,6 +31,8 @@ final class TibsCompilationDatabaseTests: XCTestCase {
     let build = URL(fileURLWithPath: "/build", isDirectory: true)
     let builder = try TibsBuilder(manifest: m, sourceRoot: src, buildRoot: build, toolchain: tc)
 
+    let sdkargs = TibsBuilder.defaultSDKPath.map { ["-sdk", $0] } ?? []
+
     let expected = JSONCompilationDatabase(commands: [
       Command(
         directory: "/build",
@@ -43,8 +45,10 @@ final class TibsCompilationDatabaseTests: XCTestCase {
           "-emit-module", "-emit-module-path", "A.swiftmodule",
           "-emit-dependencies",
           "-pch-output-dir", "pch",
-          "-module-cache-path", "ModuleCache",
-          "-working-directory", "/build"]),
+          "-module-cache-path", "ModuleCache"
+        ] + sdkargs + [
+          "-working-directory", "/build"
+        ]),
       Command(
         directory: "/build",
         file: "/src/b.swift",
@@ -57,8 +61,10 @@ final class TibsCompilationDatabaseTests: XCTestCase {
           "-emit-module", "-emit-module-path", "B.swiftmodule",
           "-emit-dependencies",
           "-pch-output-dir", "pch",
-          "-module-cache-path", "ModuleCache",
-          "-working-directory", "/build"]),
+          "-module-cache-path", "ModuleCache"
+        ] + sdkargs + [
+          "-working-directory", "/build"
+        ]),
       Command(
         directory: "/build",
         file: "/src/c.swift",
@@ -70,8 +76,10 @@ final class TibsCompilationDatabaseTests: XCTestCase {
           "-emit-module", "-emit-module-path", "C.swiftmodule",
           "-emit-dependencies",
           "-pch-output-dir", "pch",
-          "-module-cache-path", "ModuleCache",
-          "-working-directory", "/build"]),
+          "-module-cache-path", "ModuleCache"
+        ] + sdkargs + [
+          "-working-directory", "/build"
+        ]),
     ])
 
     XCTAssertEqual(builder.compilationDatabase, expected)
@@ -85,6 +93,8 @@ final class TibsCompilationDatabaseTests: XCTestCase {
     let build = URL(fileURLWithPath: "/build", isDirectory: true)
     let builder = try TibsBuilder(manifest: m, sourceRoot: src, buildRoot: build, toolchain: tc)
 
+    let sdkargs = TibsBuilder.defaultSDKPath.map { ["-sdk", $0] } ?? []
+
     let swiftArgs = [
       "/swiftc", "/src/a.swift", "/src/b.swift",
       "-module-name", "main",
@@ -96,6 +106,7 @@ final class TibsCompilationDatabaseTests: XCTestCase {
       "-module-cache-path", "ModuleCache",
       "-emit-objc-header", "-emit-objc-header-path", "main-Swift.h",
       "-import-objc-header", "/src/bridging-header.h",
+    ] + sdkargs + [
       "-Xcc", "-Wno-objc-root-class",
       "-working-directory", "/build"
     ]

--- a/Tests/ISDBTibsTests/TibsResolutionTests.swift
+++ b/Tests/ISDBTibsTests/TibsResolutionTests.swift
@@ -53,6 +53,11 @@ final class TibsResolutionTests: XCTestCase {
       src.appendingPathComponent("b.swift", isDirectory: false),
       src.appendingPathComponent("rec/c.swift" , isDirectory: false),
     ])
+    #if os(macOS)
+    XCTAssertNotNil(module.sdk)
+    #else
+    XCTAssertNil(module.sdk)
+    #endif
   }
 
   func testResolutionMixedLangTarget() throws {


### PR DESCRIPTION
When compiling with toolchains that do not include the swift stdlib
(e.g. the Xcode toolchain), we need the SDK path to be explicitly passed
as an argument.