### PR TITLE
CIndexStoreDB: correct dllstorage annotation

### DIFF
--- a/include/CIndexStoreDB/CIndexStoreDB.h
+++ b/include/CIndexStoreDB/CIndexStoreDB.h
@@ -26,10 +26,14 @@
 #endif
 
 #ifndef INDEXSTOREDB_PUBLIC
-# if defined (_MSC_VER)
-#  define INDEXSTOREDB_PUBLIC __declspec(dllimport)
+# if defined(_WIN32) && defined(_DLL)
+#   if defined(CIndexStoreDB_EXPORTS)
+#     define INDEXSTOREDB_PUBLIC __declspec(dllexport)
+#   else
+#     define INDEXSTOREDB_PUBLIC __declspec(dllimport)
+#   endif
 # else
-#  define INDEXSTOREDB_PUBLIC
+#   define INDEXSTOREDB_PUBLIC
 # endif
 #endif
 


### PR DESCRIPTION
The `INDEXSTORE_PUBLIC` macro was guarding based on `_MSC_VER` which is
a check for MSVC's compiler which is incorrect.  This annotation has
nothing to do with the MSVC compiler but rather the PE/COFF file format.
Adjust that to `_WIN32` as an alias for Windows.

Furthermore, correct the annotation - the functions should be given
dllexport storage when building IndexStoreDB, and dllimport storage when
building code which uses IndexStoreDB (unless it is statically built).