### PR TITLE
Use a Path that is Also Invalid on Windows in testErrors

### DIFF
--- a/Tests/IndexStoreDBTests/IndexStoreDBTests.swift
+++ b/Tests/IndexStoreDBTests/IndexStoreDBTests.swift
@@ -46,7 +46,7 @@ final class IndexStoreDBTests: XCTestCase {
 
   func testErrors() {
     checkThrows(.create("failed creating directory")) {
-      _ = try IndexStoreDB(storePath: "/nope", databasePath: "/nope", library: nil)
+      _ = try IndexStoreDB(storePath: "/nope:", databasePath: "/nope:", library: nil)
     }
 
     checkThrows(.create("could not determine indexstore library")) {


### PR DESCRIPTION
Windows is able to create the directory `/nope` since a leading `/`
indications a drive relative path. Instead, use `/nope:` which is
invalid both on POSIX and Windows.