### PR TITLE
Use include instead of import

### DIFF
--- a/Tests/INPUTS/MixedLangTarget/bridging-header.h
+++ b/Tests/INPUTS/MixedLangTarget/bridging-header.h
@@ -1,3 +1,3 @@
-#import "c.h"
+#include "c.h"
 
 void /*bridgingHeader:decl*/bridgingHeader(void);


### PR DESCRIPTION
Windows doesn't support `#import` and using `#include` instead doesn't
affect this test case.