### PR TITLE
Search for Shared Libraries Properly on Windows

### DIFF
--- a/Sources/ISDBTibs/TibsToolchain.swift
+++ b/Sources/ISDBTibs/TibsToolchain.swift
@@ -24,10 +24,16 @@ public final class TibsToolchain {
     self.swiftc = swiftc
     self.clang = clang
 
+#if os(Windows)
+    let dylibFolder = "bin"
+#else
+    let dylibFolder = "lib"
+#endif
+
     self.libIndexStore = libIndexStore ?? swiftc
       .deletingLastPathComponent()
       .deletingLastPathComponent()
-      .appendingPathComponent("lib/libIndexStore.\(TibsToolchain.dylibExt)", isDirectory: false)
+      .appendingPathComponent("\(dylibFolder)/libIndexStore.\(TibsToolchain.dylibExt)", isDirectory: false)
 
     self.tibs = tibs
     self.ninja = ninja
@@ -35,6 +41,8 @@ public final class TibsToolchain {
 
 #if os(macOS)
   public static let dylibExt = "dylib"
+#elseif os(Windows)
+  public static let dylibExt = "dll"
 #else
   public static let dylibExt = "so"
 #endif


### PR DESCRIPTION
- Shared libs have a .dll extension
- dlls are typically store in bin along side the executables on Windows