### PR TITLE
[test] Fix minimum sleep change

### DIFF
--- a/Sources/ISDBTibs/TibsToolchain.swift
+++ b/Sources/ISDBTibs/TibsToolchain.swift
@@ -82,16 +82,20 @@ public final class TibsToolchain {
     // Empirically, a little over 10 ms resolution is seen on some systems.
     let minimum: UInt32 = 20_000
     var usec: UInt32 = minimum
-    var reason: String = ""
+    var warning: String? = nil
+
     if ninjaVersion < (1, 9, 0) {
       usec = 1_000_000
-      reason = "upgrade to ninja >= 1.9.0 for high precision timestamp support"
+      warning = "upgrade to ninja >= 1.9.0 for high precision timestamp support"
     }
 
-    if usec > minimum {
-      let fsec = Float(usec) / 1_000_000
-      fputs("warning: waiting \(fsec) second\(fsec == 1.0 ? "" : "s") to ensure file timestamp " +
-            "differs; \(reason)\n", stderr)
+    if usec > 0 {
+      if let warning = warning {
+        let fsec = Float(usec) / 1_000_000
+        fputs("warning: waiting \(fsec) second\(fsec == 1.0 ? "" : "s") to ensure file timestamp " +
+              "differs; \(warning)\n", stderr)
+      }
+
 #if os(Windows)
       Sleep(usec / 1000)
 #else


### PR DESCRIPTION
My previous change to add a minimum sleep time when testing modified
sources was accidentally broken because I had `if usec > minimum` - that
was only intended to silence the warning, not disable the sleep itself.

When I tested this originally I must have gotten lucky; it seems to fail
1/20 or so in Docker for me. After this commit, I haven't seen any
failures after several hundred runs.

[SR-11356](https://bugs.swift.org/browse/SR-11356)
rdar://54612870