### PR TITLE
Fix crash when printing UnsafeMutableRawPointer

### DIFF
--- a/Sources/IndexStoreDB/IndexStoreDB.swift
+++ b/Sources/IndexStoreDB/IndexStoreDB.swift
@@ -175,8 +175,10 @@ public class IndexStoreLibrary {
   }
 }
 
-extension indexstoredb_error_t: CustomStringConvertible {
-  public var description: String {
+// Note: this cannot conform to CustomStringConvertible, since it is a typealias
+// of an UnsafeMutableRawPointer.
+extension indexstoredb_error_t {
+  var description: String {
     return String(cString: indexstoredb_error_get_description(self))
   }
 }


### PR DESCRIPTION
We accidentally added a conformance to UnsafeMutablePointer, since the
error is actually a C typedef of a void pointer. Luckily we don't care
about the conformance, only the concrete implementation here.