### PR TITLE
Update Package.swift to build on Windows

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:4.2
+// swift-tools-version:5.0
 
 import PackageDescription
 
@@ -88,8 +88,12 @@ let package = Package(
     .target(
       name: "IndexStoreDB_LLVMSupport",
       dependencies: [],
-      path: "lib/LLVMSupport"),
+      path: "lib/LLVMSupport",
+      cxxSettings: [
+        .define("LLVM_ON_WIN32", .when(platforms: [.windows])),
+      ]
+    ),
   ],
 
-  cxxLanguageStandard: .cxx11
+  cxxLanguageStandard: .cxx14
 )


### PR DESCRIPTION
- To build llvmSupport, we need to define LLVM_ON_WIN32
- To enable cxxsettings, we need swift-tools-version:5.0
- Windows needs c++14 enabled to successfully build the project. Since
  LLVM has moved to c++14, this seems like a reasonable thing to do
  anyways.

These changes allow me to build indexstore-db on Windows using swiftpm.