### PR TITLE
build: add CMake build system

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,21 @@
+cmake_minimum_required(VERSION 3.15.1)
+
+list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules)
+
+project(IndexStoreDB
+  LANGUAGES C CXX Swift)
+
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED YES)
+set(CMAKE_CXX_EXTENSIONS NO)
+
+set(CMAKE_POSITION_INDEPENDENT_CODE YES)
+
+find_package(dispatch CONFIG)
+find_package(Foundation CONFIG)
+
+include(SwiftSupport)
+
+add_subdirectory(lib)
+add_subdirectory(Sources)
+add_subdirectory(cmake/modules)

--- a/Sources/CMakeLists.txt
+++ b/Sources/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_subdirectory(IndexStoreDB)

--- a/Sources/IndexStoreDB/CMakeLists.txt
+++ b/Sources/IndexStoreDB/CMakeLists.txt
@@ -1,0 +1,30 @@
+if(CMAKE_VERSION VERSION_LESS 3.16)
+  if(CMAKE_SYSTEM_NAME STREQUAL Windows)
+    set(CMAKE_LINK_LIBRARY_FLAG "-l")
+    set(CMAKE_LINK_LIBRARY_SUFFIX "")
+  endif()
+endif()
+
+add_library(IndexStoreDB
+  IndexStoreDB.swift
+  SymbolLocation.swift
+  SymbolOccurrence.swift
+  SymbolRole.swift
+  Symbol.swift)
+set_target_properties(IndexStoreDB PROPERTIES
+  Swift_MODULE_DIRECTORY ${CMAKE_BINARY_DIR}/swift
+  INTERFACE_INCLUDE_DIRECTORIES ${CMAKE_BINARY_DIR}/swift)
+target_link_libraries(IndexStoreDB PRIVATE
+  Foundation
+  CIndexStoreDB)
+
+get_swift_host_arch(swift_arch)
+install(TARGETS IndexStoreDB
+  ARCHIVE DESTINATION lib/swift$<$<NOT:$<BOOL:${BUILD_SHARED_LIBS}>>:_static>/$<LOWER_CASE:${CMAKE_SYSTEM_NAME}>
+  LIBRARY DESTINATION lib/swift$<$<NOT:$<BOOL:${BUILD_SHARED_LIBS}>>:_static>/$<LOWER_CASE:${CMAKE_SYSTEM_NAME}>
+  RUNTIME DESTINATION bin)
+install(FILES
+  ${CMAKE_BINARY_DIR}/swift/IndexStoreDB.swiftdoc
+  ${CMAKE_BINARY_DIR}/swift/IndexStoreDB.swiftmodule
+  DESTINATION lib/swift$<$<NOT:$<BOOL:${BUILD_SHARED_LIBS}>>:_static>/$<LOWER_CASE:${CMAKE_SYSTEM_NAME}>/${swift_arch})
+set_property(GLOBAL APPEND PROPERTY IndexStoreDB_EXPORTS IndexStoreDB)

--- a/cmake/modules/CMakeLists.txt
+++ b/cmake/modules/CMakeLists.txt
@@ -1,0 +1,7 @@
+
+set(IndexStoreDB_EXPORTS_FILE ${CMAKE_CURRENT_BINARY_DIR}/IndexStoreDBExports.cmake)
+configure_file(IndexStoreDBConfig.cmake.in
+  ${CMAKE_CURRENT_BINARY_DIR}/IndexStoreDBConfig.cmake)
+
+get_property(IndexStoreDB_EXPORTS GLOBAL PROPERTY IndexStoreDB_EXPORTS)
+export(TARGETS ${IndexStoreDB_EXPORTS} FILE ${IndexStoreDB_EXPORTS_FILE})

--- a/cmake/modules/IndexStoreDBConfig.cmake.in
+++ b/cmake/modules/IndexStoreDBConfig.cmake.in
@@ -1,0 +1,3 @@
+if(NOT TARGET IndexStoreDB)
+  include(@IndexStoreDB_EXPORTS_FILE@)
+endif()

--- a/cmake/modules/SwiftSupport.cmake
+++ b/cmake/modules/SwiftSupport.cmake
@@ -1,0 +1,37 @@
+
+# Returns the current architecture name in a variable
+#
+# Usage:
+#   get_swift_host_arch(result_var_name)
+#
+# If the current architecture is supported by Swift, sets ${result_var_name}
+# with the sanitized host architecture name derived from CMAKE_SYSTEM_PROCESSOR.
+function(get_swift_host_arch result_var_name)
+  if("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "x86_64")
+    set("${result_var_name}" "x86_64" PARENT_SCOPE)
+  elseif("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "aarch64")
+    set("${result_var_name}" "aarch64" PARENT_SCOPE)
+  elseif("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "ppc64")
+    set("${result_var_name}" "powerpc64" PARENT_SCOPE)
+  elseif("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "ppc64le")
+    set("${result_var_name}" "powerpc64le" PARENT_SCOPE)
+  elseif("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "s390x")
+    set("${result_var_name}" "s390x" PARENT_SCOPE)
+  elseif("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "armv6l")
+    set("${result_var_name}" "armv6" PARENT_SCOPE)
+  elseif("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "armv7l")
+    set("${result_var_name}" "armv7" PARENT_SCOPE)
+  elseif("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "armv7-a")
+    set("${result_var_name}" "armv7" PARENT_SCOPE)
+  elseif("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "AMD64")
+    set("${result_var_name}" "x86_64" PARENT_SCOPE)
+  elseif("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "IA64")
+    set("${result_var_name}" "itanium" PARENT_SCOPE)
+  elseif("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "x86")
+    set("${result_var_name}" "i686" PARENT_SCOPE)
+  elseif("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "i686")
+    set("${result_var_name}" "i686" PARENT_SCOPE)
+  else()
+    message(FATAL_ERROR "Unrecognized architecture on host system: ${CMAKE_SYSTEM_PROCESSOR}")
+  endif()
+endfunction()

--- a/include/CIndexStoreDB/CIndexStoreDB.h
+++ b/include/CIndexStoreDB/CIndexStoreDB.h
@@ -26,7 +26,7 @@
 #endif
 
 #ifndef INDEXSTOREDB_PUBLIC
-# if defined(_WIN32) && defined(_DLL)
+# if defined(_WIN32) && defined(_WINDLL)
 #   if defined(CIndexStoreDB_EXPORTS)
 #     define INDEXSTOREDB_PUBLIC __declspec(dllexport)
 #   else

--- a/lib/CIndexStoreDB/CMakeLists.txt
+++ b/lib/CIndexStoreDB/CMakeLists.txt
@@ -1,0 +1,14 @@
+add_library(CIndexStoreDB STATIC
+  CIndexStoreDB.cpp)
+target_compile_options(CIndexStoreDB PRIVATE
+  -fblocks)
+target_include_directories(CIndexStoreDB PUBLIC
+  include)
+target_link_libraries(CIndexStoreDB PRIVATE
+  dispatch
+  Index
+  LLVMSupport)
+
+if(NOT BUILD_SHARED_LIBS)
+  set_property(GLOBAL APPEND PROPERTY IndexStoreDB_EXPORTS CIndexStoreDB)
+endif()

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -1,0 +1,6 @@
+add_subdirectory(LLVMSupport)
+add_subdirectory(Support)
+add_subdirectory(Core)
+add_subdirectory(Database)
+add_subdirectory(Index)
+add_subdirectory(CIndexStoreDB)

--- a/lib/Core/CMakeLists.txt
+++ b/lib/Core/CMakeLists.txt
@@ -1,0 +1,11 @@
+add_library(Core STATIC
+  Symbol.cpp)
+target_include_directories(Core PRIVATE
+  include)
+target_link_libraries(Core PRIVATE
+  Support
+  LLVMSupport)
+
+if(NOT BUILD_SHARED_LIBS)
+  set_property(GLOBAL APPEND PROPERTY IndexStoreDB_EXPORTS Core)
+endif()

--- a/lib/Database/CMakeLists.txt
+++ b/lib/Database/CMakeLists.txt
@@ -1,0 +1,19 @@
+add_library(Database STATIC
+  Database.cpp
+  DatabaseError.cpp
+  ImportTransaction.cpp
+  ReadTransaction.cpp
+  lmdb/mdb.c
+  lmdb/midl.c)
+target_compile_options(Database PRIVATE
+  -fblocks)
+target_include_directories(Database PRIVATE
+  include)
+target_link_libraries(Database PRIVATE
+  dispatch
+  Core
+  LLVMSupport)
+
+if(NOT BUILD_SHARED_LIBS)
+  set_property(GLOBAL APPEND PROPERTY IndexStoreDB_EXPORTS Database)
+endif()

--- a/lib/Index/CMakeLists.txt
+++ b/lib/Index/CMakeLists.txt
@@ -1,0 +1,21 @@
+add_library(Index STATIC
+  FilePathIndex.cpp
+  FileVisibilityChecker.cpp
+  IndexDatastore.cpp
+  indexstore_functions.def
+  IndexStoreLibraryProvider.cpp
+  IndexSystem.cpp
+  StoreSymbolRecord.cpp
+  SymbolIndex.cpp)
+target_compile_options(Index PRIVATE
+  -fblocks)
+target_include_directories(Index PRIVATE
+  include)
+target_link_libraries(Index PRIVATE
+  dispatch
+  Database
+  LLVMSupport)
+
+if(NOT BUILD_SHARED_LIBS)
+  set_property(GLOBAL APPEND PROPERTY IndexStoreDB_EXPORTS Index)
+endif()

--- a/lib/LLVMSupport/CMakeLists.txt
+++ b/lib/LLVMSupport/CMakeLists.txt
@@ -1,0 +1,77 @@
+add_library(LLVMSupport STATIC
+  Support/AArch64TargetParser.cpp
+  Support/Allocator.cpp
+  Support/APFloat.cpp
+  Support/APInt.cpp
+  Support/APSInt.cpp
+  Support/ARMTargetParser.cpp
+  Support/Atomic.cpp
+  Support/Chrono.cpp
+  Support/circular_raw_ostream.cpp
+  Support/CommandLine.cpp
+  Support/ConvertUTF.cpp
+  Support/ConvertUTFWrapper.cpp
+  Support/Debug.cpp
+  Support/DJB.cpp
+  Support/Errno.cpp
+  Support/Error.cpp
+  Support/ErrorHandling.cpp
+  Support/FileUtilities.cpp
+  Support/FoldingSet.cpp
+  Support/FormatVariadic.cpp
+  Support/Hashing.cpp
+  Support/Host.cpp
+  Support/JSON.cpp
+  Support/LineIterator.cpp
+  Support/Locale.cpp
+  Support/ManagedStatic.cpp
+  Support/MathExtras.cpp
+  Support/MD5.cpp
+  Support/MemoryBuffer.cpp
+  Support/Memory.cpp
+  Support/Mutex.cpp
+  Support/NativeFormatting.cpp
+  Support/Optional.cpp
+  Support/Options.cpp
+  Support/Path.cpp
+  Support/PrettyStackTrace.cpp
+  Support/Process.cpp
+  Support/Program.cpp
+  Support/raw_ostream.cpp
+  Support/Signals.cpp
+  Support/Signposts.cpp
+  Support/SmallPtrSet.cpp
+  Support/SmallVector.cpp
+  Support/SourceMgr.cpp
+  Support/Statistic.cpp
+  Support/StringExtras.cpp
+  Support/StringMap.cpp
+  Support/StringRef.cpp
+  Support/StringSaver.cpp
+  Support/TargetParser.cpp
+  Support/Threading.cpp
+  Support/Timer.cpp
+  Support/ToolOutputFile.cpp
+  Support/Triple.cpp
+  Support/Twine.cpp
+  Support/UnicodeCaseFold.cpp
+  Support/Unicode.cpp
+  Support/Valgrind.cpp
+  Support/VersionTuple.cpp
+  Support/Watchdog.cpp
+  Support/WithColor.cpp
+  Support/YAMLParser.cpp
+  Support/YAMLTraits.cpp)
+target_compile_definitions(LLVMSupport PUBLIC
+  LLVM_ENABLE_EXCEPTIONS=1)
+if(CMAKE_CXX_SIMULATE_ID MATCHES MSVC)
+  target_compile_options(LLVMSupport PUBLIC
+    /EHsc
+    /GR)
+endif()
+target_include_directories(LLVMSupport PUBLIC
+  ${CMAKE_CURRENT_SOURCE_DIR}/include)
+
+if(NOT BUILD_SHARED_LIBS)
+  set_property(GLOBAL APPEND PROPERTY IndexStoreDB_EXPORTS LLVMSupport)
+endif()

--- a/lib/Support/CMakeLists.txt
+++ b/lib/Support/CMakeLists.txt
@@ -1,0 +1,19 @@
+add_library(Support STATIC
+  Concurrency-Mac.cpp
+  FilePathWatcher.cpp
+  Logging.cpp
+  Logging-Mac.mm
+  Logging-NonMac.cpp
+  Path.cpp
+  PatternMatching.cpp)
+target_compile_options(Support PRIVATE
+  -fblocks)
+target_include_directories(Support PRIVATE
+  include)
+target_link_libraries(Support PRIVATE
+  dispatch
+  LLVMSupport)
+
+if(NOT BUILD_SHARED_LIBS)
+  set_property(GLOBAL APPEND PROPERTY IndexStoreDB_EXPORTS Support)
+endif()


### PR DESCRIPTION
Add a CMake build system to enable building this on platforms where it is
not currently viable to build using swift-package-manager.  This is
intended to be a mechanism to enable bootstrapping SourceKit-LSP for
platforms such as Windows.