### PR TITLE
Pass through waitUntilDoneInitializing option in Index init

### DIFF
--- a/Sources/IndexStoreDB/IndexStoreDB.swift
+++ b/Sources/IndexStoreDB/IndexStoreDB.swift
@@ -34,6 +34,16 @@ public final class IndexStoreDB {
 
   let impl: indexstoredb_index_t
 
+  /// Create or open an IndexStoreDB at the givin `databasePath`.
+  ///
+  /// * Parameters:
+  ///   * storePath: Path to the index store.
+  ///   * databasePath: Path to the index database (or where it will be created).
+  ///   * library: The index store library to use.
+  ///   * readonly: If `true`, read an existing database, but do not create or modify.
+  ///   * listenToUnitEvents: Only `true` is supported outside unit tests. Setting to `false`
+  ///     disables reading or updating from the index store unless `pollForUnitChangesAndWait()`
+  ///     is called.
   public init(
     storePath: String,
     databasePath: String,

--- a/Sources/IndexStoreDB/IndexStoreDB.swift
+++ b/Sources/IndexStoreDB/IndexStoreDB.swift
@@ -40,6 +40,8 @@ public final class IndexStoreDB {
   ///   * storePath: Path to the index store.
   ///   * databasePath: Path to the index database (or where it will be created).
   ///   * library: The index store library to use.
+  ///   * wait: If `true`, wait for the database to be populated from the
+  ///     (current) contents of the index store at `storePath` before returning.
   ///   * readonly: If `true`, read an existing database, but do not create or modify.
   ///   * listenToUnitEvents: Only `true` is supported outside unit tests. Setting to `false`
   ///     disables reading or updating from the index store unless `pollForUnitChangesAndWait()`
@@ -48,6 +50,7 @@ public final class IndexStoreDB {
     storePath: String,
     databasePath: String,
     library: IndexStoreLibrary?,
+    waitUntilDoneInitializing wait: Bool = false,
     readonly: Bool = false,
     listenToUnitEvents: Bool = true
   ) throws {
@@ -57,7 +60,7 @@ public final class IndexStoreDB {
     }
 
     var error: indexstoredb_error_t? = nil
-    guard let index = indexstoredb_index_create(storePath, databasePath, libProviderFunc, readonly, listenToUnitEvents, &error) else {
+    guard let index = indexstoredb_index_create(storePath, databasePath, libProviderFunc, wait, readonly, listenToUnitEvents, &error) else {
       defer { indexstoredb_error_dispose(error) }
       throw IndexStoreDBError.create(error?.description ?? "unknown")
     }

--- a/Tests/IndexStoreDBTests/XCTestManifests.swift
+++ b/Tests/IndexStoreDBTests/XCTestManifests.swift
@@ -19,6 +19,7 @@ extension IndexTests {
         ("testEditsSimple", testEditsSimple),
         ("testMixedLangTarget", testMixedLangTarget),
         ("testSwiftModules", testSwiftModules),
+        ("testWaitUntilDoneInitializing", testWaitUntilDoneInitializing),
     ]
 }
 

--- a/include/CIndexStoreDB/CIndexStoreDB.h
+++ b/include/CIndexStoreDB/CIndexStoreDB.h
@@ -133,6 +133,7 @@ indexstoredb_index_t
 indexstoredb_index_create(const char * _Nonnull storePath,
                   const char * _Nonnull databasePath,
                   _Nonnull indexstore_library_provider_t libProvider,
+                  bool wait,
                   bool readonly,
                   bool listenToUnitEvents,
                   indexstoredb_error_t _Nullable * _Nullable);

--- a/lib/CIndexStoreDB/CIndexStoreDB.cpp
+++ b/lib/CIndexStoreDB/CIndexStoreDB.cpp
@@ -74,7 +74,7 @@ public:
 indexstoredb_index_t
 indexstoredb_index_create(const char *storePath, const char *databasePath,
                           indexstore_library_provider_t libProvider,
-                          bool readonly, bool listenToUnitEvents,
+                          bool wait, bool readonly, bool listenToUnitEvents,
                           indexstoredb_error_t *error) {
 
   auto delegate = std::make_shared<IndexSystemDelegate>();
@@ -84,6 +84,9 @@ indexstoredb_index_create(const char *storePath, const char *databasePath,
   if (auto index =
           IndexSystem::create(storePath, databasePath, libProviderObj, delegate,
                               readonly, listenToUnitEvents, llvm::None, errMsg)) {
+
+    if (wait)
+      index->waitUntilDoneInitializing();
 
     return make_object(index);
 


### PR DESCRIPTION
When initializing the database, allow waiting for the initial scan to
finish. The existing behaviour is useful for tools like an editor where
you want to return as quickly as possible and don't need to wait for the
data to populate, but for something like a command-line tool making a
query where it expects the data to be ready we needed a way to finish
loading before continuing.