### PR TITLE
Android: add support in TibsToolchain, LLVM config, and fix lmdb ifdefs

### DIFF
--- a/Sources/ISDBTibs/TibsToolchain.swift
+++ b/Sources/ISDBTibs/TibsToolchain.swift
@@ -55,7 +55,8 @@ public final class TibsToolchain {
   }()
 
   public private(set) lazy var clangHasIndexSupport: Bool = {
-    clangVersionOutput.starts(with: "Apple") || clangVersionOutput.contains("swift-clang")
+    clangVersionOutput.starts(with: "Apple") || clangVersionOutput.contains("swift-clang") ||
+    clangVersionOutput.contains("apple/llvm-project")
   }()
 
   public private(set) lazy var ninjaVersion: (Int, Int, Int) = {
@@ -189,6 +190,8 @@ public func findTool(name: String) -> URL? {
     .appendingPathComponent("system32")
     .appendingPathComponent("where.exe")
   let cmd = [wherePath, name]
+#elseif os(Android)
+  let cmd = ["/system/bin/which", name]
 #else
   let cmd = ["/usr/bin/which", name]
 #endif

--- a/Utilities/import-llvm.d/include/llvm/Config/config.h
+++ b/Utilities/import-llvm.d/include/llvm/Config/config.h
@@ -17,7 +17,9 @@
 #define LLVM_ENABLE_CRASH_DUMPS 0
 
 /* Define to 1 if you have the `backtrace' function. */
+#if !defined(__ANDROID__)
 #define HAVE_BACKTRACE TRUE
+#endif
 
 #define BACKTRACE_HEADER <execinfo.h>
 
@@ -86,7 +88,9 @@
 /* #undef HAVE_FFI_H */
 
 /* Define to 1 if you have the `futimens' function. */
-/* #undef HAVE_FUTIMENS */
+#if defined(__ANDROID__)
+#define HAVE_FUTIMENS 1
+#endif
 
 /* Define to 1 if you have the `futimes' function. */
 #define HAVE_FUTIMES 1
@@ -118,7 +122,9 @@
 #define HAVE_LIBPTHREAD 1
 
 /* Define to 1 if you have the `pthread_getname_np' function. */
+#if !defined(__ANDROID__)
 #define HAVE_PTHREAD_GETNAME_NP 1
+#endif
 
 /* Define to 1 if you have the `pthread_setname_np' function. */
 #define HAVE_PTHREAD_SETNAME_NP 1

--- a/include/llvm/Config/config.h
+++ b/include/llvm/Config/config.h
@@ -17,7 +17,9 @@
 #define LLVM_ENABLE_CRASH_DUMPS 0
 
 /* Define to 1 if you have the `backtrace' function. */
+#if !defined(__ANDROID__)
 #define HAVE_BACKTRACE TRUE
+#endif
 
 #define BACKTRACE_HEADER <execinfo.h>
 
@@ -86,7 +88,9 @@
 /* #undef HAVE_FFI_H */
 
 /* Define to 1 if you have the `futimens' function. */
-/* #undef HAVE_FUTIMENS */
+#if defined(__ANDROID__)
+#define HAVE_FUTIMENS 1
+#endif
 
 /* Define to 1 if you have the `futimes' function. */
 #define HAVE_FUTIMES 1
@@ -118,7 +122,9 @@
 #define HAVE_LIBPTHREAD 1
 
 /* Define to 1 if you have the `pthread_getname_np' function. */
+#if !defined(__ANDROID__)
 #define HAVE_PTHREAD_GETNAME_NP 1
+#endif
 
 /* Define to 1 if you have the `pthread_setname_np' function. */
 #define HAVE_PTHREAD_SETNAME_NP 1

--- a/lib/Database/lmdb/mdb.c
+++ b/lib/Database/lmdb/mdb.c
@@ -144,7 +144,7 @@ typedef SSIZE_T	ssize_t;
 #include <unistd.h>
 #endif
 
-#if defined(__sun) || defined(ANDROID)
+#if defined(__sun) || defined(__ANDROID__)
 /* Most platforms have posix_memalign, older may only have memalign */
 #define HAVE_MEMALIGN	1
 #include <malloc.h>
@@ -164,7 +164,7 @@ typedef SSIZE_T	ssize_t;
 # define MDB_USE_SYSV_SEM	1
 # endif
 # define MDB_FDATASYNC		fsync
-#elif defined(ANDROID)
+#elif defined(__ANDROID__)
 # define MDB_FDATASYNC		fsync
 #endif
 
@@ -310,7 +310,7 @@ union semun {
  */
 #ifndef MDB_USE_ROBUST
 /* Android currently lacks Robust Mutex support. So does glibc < 2.4. */
-# if defined(MDB_USE_POSIX_MUTEX) && (defined(ANDROID) || \
+# if defined(MDB_USE_POSIX_MUTEX) && (defined(__ANDROID__) || \
 	(defined(__GLIBC__) && GLIBC_VER < 0x020004))
 #  define MDB_USE_ROBUST	0
 # else


### PR DESCRIPTION
I used this pull to build and test natively on Android in [the Termux app](https://termux.com/), all tests passing.