### PR TITLE
[libindexstore] Remove indexstore_unit_event_get_modification_time

### DIFF
--- a/include/indexstore/IndexStoreCXX.h
+++ b/include/indexstore/IndexStoreCXX.h
@@ -185,8 +185,6 @@ public:
     StringRef getUnitName() const {
       return stringFromIndexStoreStringRef(lib->api().unit_event_get_unit_name(obj));
     }
-
-    timespec getModificationTime() const { return lib->api().unit_event_get_modification_time(obj); }
   };
 
   class UnitEventNotification {

--- a/include/indexstore/indexstore_functions.h
+++ b/include/indexstore/indexstore_functions.h
@@ -266,10 +266,6 @@ typedef struct {
   indexstore_string_ref_t
   (*unit_event_get_unit_name)(indexstore_unit_event_t);
 
-  struct timespec
-  (*unit_event_get_modification_time)(indexstore_unit_event_t);
-
-
   #if INDEXSTORE_HAS_BLOCKS
   void
   (*store_set_unit_event_handler)(indexstore_t,

--- a/lib/Index/indexstore_functions.def
+++ b/lib/Index/indexstore_functions.def
@@ -16,7 +16,6 @@ INDEXSTORE_FUNCTION(unit_event_notification_get_event, true)
 INDEXSTORE_FUNCTION(unit_event_notification_is_initial, true)
 INDEXSTORE_FUNCTION(unit_event_get_kind, true)
 INDEXSTORE_FUNCTION(unit_event_get_unit_name, true)
-INDEXSTORE_FUNCTION(unit_event_get_modification_time, true)
 #if INDEXSTORE_HAS_BLOCKS
 INDEXSTORE_FUNCTION(store_set_unit_event_handler, true)
 #endif


### PR DESCRIPTION
This was removed from the implementation. While this is an ABI break,
it's one that we may be able to accept since we aren't using this
function for anything in practice.

rdar://58836941