### PR TITLE
Revert "Create the index store path if it does not exist"

### DIFF
--- a/Sources/ISDBTestSupport/TibsTestWorkspace.swift
+++ b/Sources/ISDBTestSupport/TibsTestWorkspace.swift
@@ -74,6 +74,7 @@ public final class TibsTestWorkspace {
 
     try fm.createDirectory(at: persistentBuildDir, withIntermediateDirectories: true, attributes: nil)
     let databaseDir = tmpDir
+    try fm.createDirectory(at: databaseDir, withIntermediateDirectories: true, attributes: nil)
 
     self.sources = try TestSources(rootDirectory: projectDir)
 
@@ -84,13 +85,15 @@ public final class TibsTestWorkspace {
       buildRoot: persistentBuildDir,
       toolchain: toolchain)
 
+    try fm.createDirectory(at: builder.indexstore, withIntermediateDirectories: true, attributes: nil)
+
     try builder.writeBuildFiles()
 
     let libIndexStore = try IndexStoreLibrary(dylibPath: toolchain.libIndexStore.path)
 
     self.index = try IndexStoreDB(
       storePath: builder.indexstore.path,
-      databasePath: databaseDir.path,
+      databasePath: tmpDir.path,
       library: libIndexStore,
       listenToUnitEvents: false)
   }
@@ -120,6 +123,7 @@ public final class TibsTestWorkspace {
     let sourceDir = tmpDir.appendingPathComponent("src", isDirectory: true)
     try fm.copyItem(at: projectDir, to: sourceDir)
     let databaseDir = tmpDir.appendingPathComponent("db", isDirectory: true)
+    try fm.createDirectory(at: databaseDir, withIntermediateDirectories: true, attributes: nil)
 
     self.sources = try TestSources(rootDirectory: sourceDir)
 
@@ -130,13 +134,15 @@ public final class TibsTestWorkspace {
       buildRoot: buildDir,
       toolchain: toolchain)
 
+    try fm.createDirectory(at: builder.indexstore, withIntermediateDirectories: true, attributes: nil)
+
     try builder.writeBuildFiles()
 
     let libIndexStore = try IndexStoreLibrary(dylibPath: toolchain.libIndexStore.path)
 
     self.index = try IndexStoreDB(
       storePath: builder.indexstore.path,
-      databasePath: databaseDir.path,
+      databasePath: tmpDir.path,
       library: libIndexStore,
       listenToUnitEvents: false)
   }

--- a/Tests/IndexStoreDBTests/IndexStoreDBTests.swift
+++ b/Tests/IndexStoreDBTests/IndexStoreDBTests.swift
@@ -11,7 +11,6 @@
 //===----------------------------------------------------------------------===//
 
 import IndexStoreDB
-import ISDBTibs
 import XCTest
 import Foundation
 
@@ -52,23 +51,6 @@ final class IndexStoreDBTests: XCTestCase {
 
     checkThrows(.create("could not determine indexstore library")) {
       _ = try IndexStoreDB(storePath: "\(tmp)/idx", databasePath: "\(tmp)/db", library: nil)
-    }
-  }
-
-  func testCreateIndexStoreAndDBDirs() {
-    let toolchain = TibsToolchain.testDefault
-    let libIndexStore = try! IndexStoreLibrary(dylibPath: toolchain.libIndexStore.path)
-
-    // Normal - create the missing directories.
-    XCTAssertNoThrow(try IndexStoreDB(storePath: tmp + "/store", databasePath: tmp + "/db", library: libIndexStore))
-
-    // Readonly - do not create.
-    checkThrows(.create("failed opening database")) {
-      _ = try IndexStoreDB(storePath: tmp + "/store", databasePath: tmp + "/db-readonly", library: libIndexStore, readonly: true)
-    }
-    // Readonly - do not create.
-    checkThrows(.create("index store path does not exist")) {
-      _ = try IndexStoreDB(storePath: tmp + "/store-readonly", databasePath: tmp + "/db", library: libIndexStore, readonly: true)
     }
   }
 

--- a/Tests/IndexStoreDBTests/XCTestManifests.swift
+++ b/Tests/IndexStoreDBTests/XCTestManifests.swift
@@ -6,7 +6,6 @@ extension IndexStoreDBTests {
     //   `swift test --generate-linuxmain`
     // to regenerate.
     static let __allTests__IndexStoreDBTests = [
-        ("testCreateIndexStoreAndDBDirs", testCreateIndexStoreAndDBDirs),
         ("testErrors", testErrors),
     ]
 }

--- a/lib/Index/IndexSystem.cpp
+++ b/lib/Index/IndexSystem.cpp
@@ -26,7 +26,6 @@
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/StringRef.h"
-#include "llvm/Support/FileSystem.h"
 #include "llvm/Support/raw_ostream.h"
 
 #include <unordered_map>
@@ -210,14 +209,6 @@ bool IndexSystemImpl::init(StringRef StorePath,
   if (!idxStoreLib) {
     Error = "could not determine indexstore library";
     return true;
-  }
-
-  if (!readonly) {
-    // Create the index store path, if it does not already exist.
-    if (std::error_code EC = llvm::sys::fs::create_directories(StorePath)) {
-      Error = "could not create directories for data store path ";
-      Error += StorePath.str() + ": " + EC.message();
-    }
   }
 
   auto idxStore = indexstore::IndexStore::create(StorePath, idxStoreLib, Error);


### PR DESCRIPTION
Reverts apple/indexstore-db#65

This [breaks CI](https://ci.swift.org/job/oss-swift-master-rebranch-incremental-RA-linux-ubuntu-16_04-long-test/56/console) for master-rebranch.

```bash
inotify_add_watch() error: No such file or directory
```

It appears that DirectoryWatcher no longer creates the directory to be watched, so while there will be `indexstore`, there will not be `indexstore/vN/units` that it is expecting.  This should get fixed in clang, since we should not be guessing what the structure if from outside libIndexStore.
