### PR TITLE
Reapply "Create the index store path if it does not exist"

### DIFF
--- a/Sources/ISDBTestSupport/TibsTestWorkspace.swift
+++ b/Sources/ISDBTestSupport/TibsTestWorkspace.swift
@@ -74,7 +74,6 @@ public final class TibsTestWorkspace {
 
     try fm.createDirectory(at: persistentBuildDir, withIntermediateDirectories: true, attributes: nil)
     let databaseDir = tmpDir
-    try fm.createDirectory(at: databaseDir, withIntermediateDirectories: true, attributes: nil)
 
     self.sources = try TestSources(rootDirectory: projectDir)
 
@@ -85,15 +84,13 @@ public final class TibsTestWorkspace {
       buildRoot: persistentBuildDir,
       toolchain: toolchain)
 
-    try fm.createDirectory(at: builder.indexstore, withIntermediateDirectories: true, attributes: nil)
-
     try builder.writeBuildFiles()
 
     let libIndexStore = try IndexStoreLibrary(dylibPath: toolchain.libIndexStore.path)
 
     self.index = try IndexStoreDB(
       storePath: builder.indexstore.path,
-      databasePath: tmpDir.path,
+      databasePath: databaseDir.path,
       library: libIndexStore,
       listenToUnitEvents: false)
   }
@@ -123,7 +120,6 @@ public final class TibsTestWorkspace {
     let sourceDir = tmpDir.appendingPathComponent("src", isDirectory: true)
     try fm.copyItem(at: projectDir, to: sourceDir)
     let databaseDir = tmpDir.appendingPathComponent("db", isDirectory: true)
-    try fm.createDirectory(at: databaseDir, withIntermediateDirectories: true, attributes: nil)
 
     self.sources = try TestSources(rootDirectory: sourceDir)
 
@@ -134,15 +130,13 @@ public final class TibsTestWorkspace {
       buildRoot: buildDir,
       toolchain: toolchain)
 
-    try fm.createDirectory(at: builder.indexstore, withIntermediateDirectories: true, attributes: nil)
-
     try builder.writeBuildFiles()
 
     let libIndexStore = try IndexStoreLibrary(dylibPath: toolchain.libIndexStore.path)
 
     self.index = try IndexStoreDB(
       storePath: builder.indexstore.path,
-      databasePath: tmpDir.path,
+      databasePath: databaseDir.path,
       library: libIndexStore,
       listenToUnitEvents: false)
   }

--- a/Tests/IndexStoreDBTests/IndexStoreDBTests.swift
+++ b/Tests/IndexStoreDBTests/IndexStoreDBTests.swift
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 import IndexStoreDB
+import ISDBTibs
 import XCTest
 import Foundation
 
@@ -51,6 +52,23 @@ final class IndexStoreDBTests: XCTestCase {
 
     checkThrows(.create("could not determine indexstore library")) {
       _ = try IndexStoreDB(storePath: "\(tmp)/idx", databasePath: "\(tmp)/db", library: nil)
+    }
+  }
+
+  func testCreateIndexStoreAndDBDirs() {
+    let toolchain = TibsToolchain.testDefault
+    let libIndexStore = try! IndexStoreLibrary(dylibPath: toolchain.libIndexStore.path)
+
+    // Normal - create the missing directories.
+    XCTAssertNoThrow(try IndexStoreDB(storePath: tmp + "/store", databasePath: tmp + "/db", library: libIndexStore))
+
+    // Readonly - do not create.
+    checkThrows(.create("failed opening database")) {
+      _ = try IndexStoreDB(storePath: tmp + "/store", databasePath: tmp + "/db-readonly", library: libIndexStore, readonly: true)
+    }
+    // Readonly - do not create.
+    checkThrows(.create("index store path does not exist")) {
+      _ = try IndexStoreDB(storePath: tmp + "/store-readonly", databasePath: tmp + "/db", library: libIndexStore, readonly: true)
     }
   }
 

--- a/Tests/IndexStoreDBTests/XCTestManifests.swift
+++ b/Tests/IndexStoreDBTests/XCTestManifests.swift
@@ -6,6 +6,7 @@ extension IndexStoreDBTests {
     //   `swift test --generate-linuxmain`
     // to regenerate.
     static let __allTests__IndexStoreDBTests = [
+        ("testCreateIndexStoreAndDBDirs", testCreateIndexStoreAndDBDirs),
         ("testErrors", testErrors),
     ]
 }

--- a/lib/Index/IndexSystem.cpp
+++ b/lib/Index/IndexSystem.cpp
@@ -26,6 +26,7 @@
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/StringRef.h"
+#include "llvm/Support/FileSystem.h"
 #include "llvm/Support/raw_ostream.h"
 
 #include <unordered_map>
@@ -209,6 +210,14 @@ bool IndexSystemImpl::init(StringRef StorePath,
   if (!idxStoreLib) {
     Error = "could not determine indexstore library";
     return true;
+  }
+
+  if (!readonly) {
+    // Create the index store path, if it does not already exist.
+    if (std::error_code EC = llvm::sys::fs::create_directories(StorePath)) {
+      Error = "could not create directories for data store path ";
+      Error += StorePath.str() + ": " + EC.message();
+    }
   }
 
   auto idxStore = indexstore::IndexStore::create(StorePath, idxStoreLib, Error);


### PR DESCRIPTION
Reapply apple/indexstore-db#65.  Depends on  https://github.com/apple/llvm-project/pull/710 being merged it into `swift/master-rebranch`.

---

We already do this for the database, so add the store as well. This allows you to open the index before it has been populated.