### PR TITLE
Expose the name of every symbol in the index 

### DIFF
--- a/Sources/IndexStoreDB/IndexStoreDB.swift
+++ b/Sources/IndexStoreDB/IndexStoreDB.swift
@@ -199,11 +199,11 @@ public final class IndexStoreDB {
     }
   }
 
-  /// Returns a set with every symbol in the index.
-  public func allSymbolNames() -> Set<String> {
-    var result: Set<String> = []
+  /// Returns an array with every symbol name in the index.
+  public func allSymbolNames() -> [String] {
+    var result: [String] = []
     forEachSymbolName { name in
-      result.insert(name)
+      result.append(name)
       return true
     }
     return result

--- a/Tests/IndexStoreDBTests/IndexTests.swift
+++ b/Tests/IndexStoreDBTests/IndexTests.swift
@@ -279,4 +279,14 @@ final class IndexTests: XCTestCase {
     XCTAssertEqual(mainFiles(unknown, true), [])
     XCTAssertEqual(mainFiles(unknown, false), [])
   }
+
+  func testAllSymbolNames() throws {
+    guard let ws = try staticTibsTestWorkspace(name: "proj1") else { return }
+    try ws.buildAndIndex()
+    let index = ws.index
+
+    let expectedSymbolNames = ["a()", "b()", "c()"]
+
+    XCTAssertEqual(index.allSymbolNames(), expectedSymbolNames)
+  }
 }

--- a/Tests/IndexStoreDBTests/XCTestManifests.swift
+++ b/Tests/IndexStoreDBTests/XCTestManifests.swift
@@ -16,6 +16,7 @@ extension IndexTests {
     //   `swift test --generate-linuxmain`
     // to regenerate.
     static let __allTests__IndexTests = [
+        ("testAllSymbolNames", testAllSymbolNames),
         ("testBasic", testBasic),
         ("testDelegate", testDelegate),
         ("testEditsSimple", testEditsSimple),


### PR DESCRIPTION
There are scenarios where one wants to iterate through the list of all the symbols in the index. Such functionality exists in the underlying lower-level library. 

This PR makes that functionality available to `indexstore-db` users.