### PR TITLE
[build-script][test] Remove hard-coded install prefix of /usr and pass it in instead

### DIFF
--- a/Sources/ISDBTibs/TibsToolchain.swift
+++ b/Sources/ISDBTibs/TibsToolchain.swift
@@ -132,9 +132,9 @@ extension TibsToolchain {
 
     let fm = FileManager.default
 
-    let envVar = "INDEXSTOREDB_TOOLCHAIN_PATH"
+    let envVar = "INDEXSTOREDB_TOOLCHAIN_BIN_PATH"
     if let path = ProcessInfo.processInfo.environment[envVar] {
-      let bin = URL(fileURLWithPath: "\(path)/usr/bin", isDirectory: true)
+      let bin = URL(fileURLWithPath: "\(path)/bin", isDirectory: true)
       swiftc = bin.appendingPathComponent("swiftc", isDirectory: false)
       clang = bin.appendingPathComponent("clang", isDirectory: false)
 

--- a/Utilities/build-script-helper.py
+++ b/Utilities/build-script-helper.py
@@ -37,10 +37,10 @@ def get_swiftpm_options(args):
     swiftpm_args += [
       # Dispatch headers
       '-Xcxx', '-I', '-Xcxx',
-      os.path.join(args.toolchain, 'usr', 'lib', 'swift'),
+      os.path.join(args.toolchain, 'lib', 'swift'),
       # For <Block.h>
       '-Xcxx', '-I', '-Xcxx',
-      os.path.join(args.toolchain, 'usr', 'lib', 'swift', 'Block'),
+      os.path.join(args.toolchain, 'lib', 'swift', 'Block'),
     ]
 
   return swiftpm_args
@@ -51,7 +51,7 @@ def handle_invocation(swift_exec, args):
 
   env = os.environ
   # Set the toolchain used in tests at runtime
-  env['INDEXSTOREDB_TOOLCHAIN_PATH'] = args.toolchain
+  env['INDEXSTOREDB_TOOLCHAIN_BIN_PATH'] = args.toolchain
 
   if args.ninja_bin:
     env['NINJA_BIN'] = args.ninja_bin
@@ -105,7 +105,7 @@ def main():
   args.toolchain = os.path.abspath(args.toolchain)
 
   if args.toolchain:
-    swift_exec = os.path.join(args.toolchain, 'usr', 'bin', 'swift')
+    swift_exec = os.path.join(args.toolchain, 'bin', 'swift')
   else:
     swift_exec = 'swift'
 


### PR DESCRIPTION
Because of a bug upstream in the main build-script, the install prefix set by the user wasn't being passed in to this repo and these files assumed it to be `/usr`. This pull removes that assumption and has the main build-script pass an install prefix appended to the toolchain path instead, apple/swift#30565.