### PR TITLE
build: allow building with CMake without symlinks

### DIFF
--- a/lib/CIndexStoreDB/CMakeLists.txt
+++ b/lib/CIndexStoreDB/CMakeLists.txt
@@ -3,11 +3,12 @@ add_library(CIndexStoreDB STATIC
 target_compile_options(CIndexStoreDB PRIVATE
   -fblocks)
 target_include_directories(CIndexStoreDB PUBLIC
-  include)
+  ${PROJECT_SOURCE_DIR}/include/CIndexStoreDB)
 target_link_libraries(CIndexStoreDB PRIVATE
   dispatch
-  Index
   LLVMSupport)
+target_link_libraries(CIndexStoreDB PUBLIC
+  Index)
 
 if(NOT BUILD_SHARED_LIBS)
   set_property(GLOBAL APPEND PROPERTY IndexStoreDB_EXPORTS CIndexStoreDB)

--- a/lib/Index/CMakeLists.txt
+++ b/lib/Index/CMakeLists.txt
@@ -9,8 +9,8 @@ add_library(Index STATIC
   SymbolIndex.cpp)
 target_compile_options(Index PRIVATE
   -fblocks)
-target_include_directories(Index PRIVATE
-  include)
+target_include_directories(Index PUBLIC
+  ${PROJECT_SOURCE_DIR}/include)
 target_link_libraries(Index PRIVATE
   dispatch
   Database

--- a/lib/LLVMSupport/CMakeLists.txt
+++ b/lib/LLVMSupport/CMakeLists.txt
@@ -70,7 +70,7 @@ if(CMAKE_CXX_SIMULATE_ID MATCHES MSVC)
     /GR)
 endif()
 target_include_directories(LLVMSupport PUBLIC
-  ${CMAKE_CURRENT_SOURCE_DIR}/include)
+  ${PROJECT_SOURCE_DIR}/include)
 
 if(NOT BUILD_SHARED_LIBS)
   set_property(GLOBAL APPEND PROPERTY IndexStoreDB_EXPORTS LLVMSupport)


### PR DESCRIPTION
Windows can still be finicky with symbolic links.  This adjusts the
include paths to allow building without relying on them.

Additionally, make the include path for `indexstore` public so that
users of it will implicitly get its headers.  Lastly, adjust the linking
for CIndexStore to use `PUBLIC` for `indexstore` to allow the header
include paths to be transitively included.  This mirrors the behaviour
of swift-package-manager.

This allows IndexStoreDB to be built on Windows again.