### PR TITLE
[build-script] Add --parallel to supress output on success

### DIFF
--- a/Utilities/build-script-helper.py
+++ b/Utilities/build-script-helper.py
@@ -86,7 +86,7 @@ def main():
     tests = os.path.join(bin_path, 'isdb-tests')
     print('Cleaning ' + tests)
     shutil.rmtree(tests, ignore_errors=True)
-    swiftpm('test', swift_exec, swiftpm_args, env)
+    swiftpm('test', swift_exec, swiftpm_args + ['--parallel'], env)
   else:
     assert False, 'unknown action \'{}\''.format(args.action)
 


### PR DESCRIPTION
It's slightly faster and it helps supress the test output when tests
succeed (which avoids false positives in Jenkins' error regexes).