### PR TITLE
[test] Workaround an issue with createDirectory on Linux

### DIFF
--- a/Sources/ISDBTestSupport/TibsTestWorkspace.swift
+++ b/Sources/ISDBTestSupport/TibsTestWorkspace.swift
@@ -83,7 +83,7 @@ public final class TibsTestWorkspace {
     let fm = FileManager.default
     _ = try? fm.removeItem(at: tmpDir)
 
-    try fm.createDirectory(at: persistentBuildDir, withIntermediateDirectories: true, attributes: nil)
+    try fm.tibs_createDirectoryWithIntermediates(at: persistentBuildDir)
     let databaseDir = tmpDir
 
     self.sources = try TestSources(rootDirectory: projectDir)
@@ -128,7 +128,7 @@ public final class TibsTestWorkspace {
     _ = try? fm.removeItem(at: tmpDir)
 
     let buildDir = tmpDir.appendingPathComponent("build", isDirectory: true)
-    try fm.createDirectory(at: buildDir, withIntermediateDirectories: true, attributes: nil)
+    try fm.tibs_createDirectoryWithIntermediates(at: buildDir)
     let sourceDir = tmpDir.appendingPathComponent("src", isDirectory: true)
     try fm.copyItem(at: projectDir, to: sourceDir)
     let databaseDir = tmpDir.appendingPathComponent("db", isDirectory: true)
@@ -285,5 +285,35 @@ extension XCTestCase {
     let className = name.dropFirst(2).prefix(while: { $0 != " " })
     let methodName = name[className.endIndex...].dropFirst().prefix(while: { $0 != "]"})
     return "\(className).\(methodName)"
+  }
+}
+
+extension FileManager {
+
+  /// Wrapper for Foundation.createDirectory that works around a spurious EEXIST
+  /// if we race to create.
+  public func tibs_createDirectoryWithIntermediates(at url: URL) throws
+  {
+#if os(macOS)
+    try self.createDirectory(at: url, withIntermediateDirectories: true, attributes: nil)
+#else
+    var i = 0
+    let maxRetries = 3
+
+    while true {
+      do {
+        try self.createDirectory(at: url, withIntermediateDirectories: true, attributes: nil)
+        return
+      } catch let error as NSError where error.code == CocoaError.fileWriteFileExists.rawValue {
+        // May be spurious if we raced.
+        i += 1
+        if i < maxRetries {
+          continue
+        } else {
+          throw error
+        }
+      }
+    }
+#endif
   }
 }


### PR DESCRIPTION
Looks like createDirectory can fail spuriously if run in parallel with a
common parent path missing. Will file a bug on corelibs-foundation, but
for now workaround to avoid test failures.

rdar://61545973