### PR TITLE
[Index] Provide capability for the client to explicitly specify the list of output unit files for the datastore

### DIFF
--- a/Sources/ISDBTestSupport/TibsTestWorkspace.swift
+++ b/Sources/ISDBTestSupport/TibsTestWorkspace.swift
@@ -73,6 +73,7 @@ public final class TibsTestWorkspace {
     persistentBuildDir: URL,
     tmpDir: URL,
     removeTmpDir: Bool = true,
+    useExplicitOutputUnits: Bool = false,
     toolchain: TibsToolchain) throws
   {
     self.projectDir = immutableProjectDir
@@ -104,6 +105,7 @@ public final class TibsTestWorkspace {
       databasePath: databaseDir.path,
       library: libIndexStore,
       delegate: wrapperDelegate,
+      useExplicitOutputUnits: useExplicitOutputUnits,
       listenToUnitEvents: false)
   }
 
@@ -118,7 +120,13 @@ public final class TibsTestWorkspace {
   ///   * toolchain: The toolchain to use for building and indexing.
   ///
   /// * throws: If there are any file system errors.
-  public init(projectDir: URL, tmpDir: URL, removeTmpDir: Bool = true, toolchain: TibsToolchain) throws {
+  public init(
+    projectDir: URL,
+    tmpDir: URL,
+    removeTmpDir: Bool = true,
+    useExplicitOutputUnits: Bool = false,
+    toolchain: TibsToolchain) throws
+  {
     self.projectDir = projectDir
     self.tmpDir = tmpDir
     self.mutableSources = true
@@ -151,6 +159,7 @@ public final class TibsTestWorkspace {
       databasePath: databaseDir.path,
       library: libIndexStore,
       delegate: wrapperDelegate,
+      useExplicitOutputUnits: useExplicitOutputUnits,
       listenToUnitEvents: false)
   }
 
@@ -198,6 +207,7 @@ extension XCTestCase {
   ///   support this test.
   public func staticTibsTestWorkspace(
     name: String,
+    useExplicitOutputUnits: Bool = false,
     testFile: String = #file
   ) throws -> TibsTestWorkspace? {
     let testDirName = testDirectoryName
@@ -211,6 +221,7 @@ extension XCTestCase {
         .appendingPathComponent("isdb-tests/\(testDirName)", isDirectory: true),
       tmpDir: URL(fileURLWithPath: NSTemporaryDirectory())
         .appendingPathComponent("isdb-test-data/\(testDirName)", isDirectory: true),
+      useExplicitOutputUnits: useExplicitOutputUnits,
       toolchain: toolchain)
 
     if workspace.builder.targets.contains(where: { target in !target.clangTUs.isEmpty })

--- a/Sources/ISDBTibs/TibsBuilder.swift
+++ b/Sources/ISDBTibs/TibsBuilder.swift
@@ -23,6 +23,10 @@ public final class TibsBuilder {
 
   public var indexstore: URL { buildRoot.appendingPathComponent("index", isDirectory: true) }
 
+  public var indexOutputPaths: [URL] {
+    return targets.flatMap{ $0.indexOutputPaths }.map{ buildRoot.appendingPathComponent($0, isDirectory: false) }
+  }
+
   public enum Error: Swift.Error {
     case duplicateTarget(String)
     case unknownDependency(String, declaredIn: String)

--- a/Sources/ISDBTibs/TibsResolvedTarget.swift
+++ b/Sources/ISDBTibs/TibsResolvedTarget.swift
@@ -33,6 +33,10 @@ public final class TibsResolvedTarget {
     public var importPaths: [String] { moduleDeps.isEmpty ? [] : ["."] }
     public var sdk: String?
 
+    public var indexOutputPaths: [String] {
+      return outputFileMap.values.compactMap{ $0.swiftmodule }
+    }
+
     public init(
       name: String,
       extraArgs: [String] = [],
@@ -82,6 +86,10 @@ public final class TibsResolvedTarget {
   public var swiftModule: SwiftModule?
   public var clangTUs: [ClangTU]
   public var dependencies: [String]
+
+  public var indexOutputPaths: [String] {
+    return clangTUs.map{ $0.outputPath } + (swiftModule?.indexOutputPaths ?? [])
+  }
 
   public init(name: String, swiftModule: SwiftModule?, clangTUs: [ClangTU], dependencies: [String]) {
     self.name = name

--- a/Sources/IndexStoreDB/IndexStoreDB.swift
+++ b/Sources/IndexStoreDB/IndexStoreDB.swift
@@ -11,7 +11,15 @@
 //===----------------------------------------------------------------------===//
 
 import CIndexStoreDB
+
+// For `strdup`
+#if canImport(Glibc)
+import Glibc
+#elseif os(Windows)
+import MSVCRT
+#else
 import Darwin.POSIX
+#endif
 
 /// IndexStoreDB index.
 public final class IndexStoreDB {

--- a/Sources/IndexStoreDB/IndexStoreDB.swift
+++ b/Sources/IndexStoreDB/IndexStoreDB.swift
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 import CIndexStoreDB
+import Darwin.POSIX
 
 /// IndexStoreDB index.
 public final class IndexStoreDB {
@@ -35,6 +36,7 @@ public final class IndexStoreDB {
     databasePath: String,
     library: IndexStoreLibrary?,
     delegate: IndexDelegate? = nil,
+    useExplicitOutputUnits: Bool = false,
     waitUntilDoneInitializing wait: Bool = false,
     readonly: Bool = false,
     listenToUnitEvents: Bool = true
@@ -61,7 +63,7 @@ public final class IndexStoreDB {
     }
 
     var error: indexstoredb_error_t? = nil
-    guard let index = indexstoredb_index_create(storePath, databasePath, libProviderFunc, delegateFunc, wait, readonly, listenToUnitEvents, &error) else {
+    guard let index = indexstoredb_index_create(storePath, databasePath, libProviderFunc, delegateFunc, useExplicitOutputUnits, wait, readonly, listenToUnitEvents, &error) else {
       defer { indexstoredb_error_dispose(error) }
       throw IndexStoreDBError.create(error?.description ?? "unknown")
     }
@@ -76,6 +78,22 @@ public final class IndexStoreDB {
   /// *For Testing* Poll for any changes to units and wait until they have been registered.
   public func pollForUnitChangesAndWait() {
     indexstoredb_index_poll_for_unit_changes_and_wait(impl)
+  }
+
+  /// Add output filepaths for the set of unit files that index data should be loaded from.
+  /// Only has an effect if `useExplicitOutputUnits` was set to true at initialization.
+  public func addUnitOutFilePaths(_ paths: [String], waitForProcessing: Bool) {
+    let cPaths: [UnsafePointer<CChar>] = paths.map { UnsafePointer($0.withCString(strdup)!) }
+    defer { for cPath in cPaths { free(UnsafeMutablePointer(mutating: cPath)) } }
+    return indexstoredb_index_add_unit_out_file_paths(impl, cPaths, cPaths.count, waitForProcessing)
+  }
+
+  /// Remove output filepaths for the set of unit files that index data should be loaded from.
+  /// Only has an effect if `useExplicitOutputUnits` was set to true at initialization.
+  public func removeUnitOutFilePaths(_ paths: [String], waitForProcessing: Bool) {
+    let cPaths: [UnsafePointer<CChar>] = paths.map { UnsafePointer($0.withCString(strdup)!) }
+    defer { for cPath in cPaths { free(UnsafeMutablePointer(mutating: cPath)) } }
+    return indexstoredb_index_remove_unit_out_file_paths(impl, cPaths, cPaths.count, waitForProcessing)
   }
 
   @discardableResult

--- a/Tests/IndexStoreDBTests/XCTestManifests.swift
+++ b/Tests/IndexStoreDBTests/XCTestManifests.swift
@@ -20,6 +20,7 @@ extension IndexTests {
         ("testBasic", testBasic),
         ("testDelegate", testDelegate),
         ("testEditsSimple", testEditsSimple),
+        ("testExplicitOutputUnits", testExplicitOutputUnits),
         ("testMainFilesContainingFile", testMainFilesContainingFile),
         ("testMixedLangTarget", testMixedLangTarget),
         ("testSwiftModules", testSwiftModules),

--- a/include/CIndexStoreDB/CIndexStoreDB.h
+++ b/include/CIndexStoreDB/CIndexStoreDB.h
@@ -146,6 +146,7 @@ indexstoredb_index_create(const char * _Nonnull storePath,
                   const char * _Nonnull databasePath,
                   _Nonnull indexstore_library_provider_t libProvider,
                   _Nonnull indexstoredb_delegate_event_receiver_t delegate,
+                  bool useExplicitOutputUnits,
                   bool wait,
                   bool readonly,
                   bool listenToUnitEvents,
@@ -162,6 +163,22 @@ indexstoredb_load_indexstore_library(const char * _Nonnull dylibPath,
 /// *For Testing* Poll for any changes to index units and wait until they have been registered.
 INDEXSTOREDB_PUBLIC void
 indexstoredb_index_poll_for_unit_changes_and_wait(_Nonnull indexstoredb_index_t index);
+
+/// Add output filepaths for the set of unit files that index data should be loaded from.
+/// Only has an effect if `useExplicitOutputUnits` was set to true for `indexstoredb_index_create`.
+INDEXSTOREDB_PUBLIC void
+indexstoredb_index_add_unit_out_file_paths(_Nonnull indexstoredb_index_t index,
+                                           const char *_Nonnull const *_Nonnull paths,
+                                           size_t count,
+                                           bool waitForProcessing);
+
+/// Remove output filepaths from the set of unit files that index data should be loaded from.
+/// Only has an effect if `useExplicitOutputUnits` was set to true for `indexstoredb_index_create`.
+INDEXSTOREDB_PUBLIC void
+indexstoredb_index_remove_unit_out_file_paths(_Nonnull indexstoredb_index_t index,
+                                              const char *_Nonnull const *_Nonnull paths,
+                                              size_t count,
+                                              bool waitForProcessing);
 
 INDEXSTOREDB_PUBLIC
 indexstoredb_delegate_event_kind_t

--- a/include/IndexStoreDB/Index/IndexSystem.h
+++ b/include/IndexStoreDB/Index/IndexSystem.h
@@ -46,6 +46,7 @@ public:
                                              StringRef dbasePath,
                                              std::shared_ptr<IndexStoreLibraryProvider> storeLibProvider,
                                              std::shared_ptr<IndexSystemDelegate> Delegate,
+                                             bool useExplicitOutputUnits,
                                              bool readonly,
                                              bool listenToUnitEvents,
                                              Optional<size_t> initialDBSize,
@@ -62,6 +63,14 @@ public:
 
   void registerMainFiles(ArrayRef<StringRef> filePaths, StringRef productName);
   void unregisterMainFiles(ArrayRef<StringRef> filePaths, StringRef productName);
+
+  /// Add output filepaths for the set of unit files that index data should be loaded from.
+  /// Only has an effect if `useExplicitOutputUnits` was set to true at initialization.
+  void addUnitOutFilePaths(ArrayRef<StringRef> filePaths, bool waitForProcessing = false);
+
+  /// Remove output filepaths from the set of unit files that index data should be loaded from.
+  /// Only has an effect if `useExplicitOutputUnits` was set to true at initialization.
+  void removeUnitOutFilePaths(ArrayRef<StringRef> filePaths, bool waitForProcessing = false);
 
   // FIXME: Accept a list of active main files so that it can remove stale unit
   // files.

--- a/lib/CIndexStoreDB/CIndexStoreDB.cpp
+++ b/lib/CIndexStoreDB/CIndexStoreDB.cpp
@@ -100,7 +100,8 @@ indexstoredb_index_t
 indexstoredb_index_create(const char *storePath, const char *databasePath,
                           indexstore_library_provider_t libProvider,
                           indexstoredb_delegate_event_receiver_t delegateCallback,
-                          bool wait, bool readonly, bool listenToUnitEvents,
+                          bool useExplicitOutputUnits, bool wait, bool readonly,
+                          bool listenToUnitEvents,
                           indexstoredb_error_t *error) {
 
   auto delegate = std::make_shared<BlockIndexSystemDelegate>(delegateCallback);
@@ -109,7 +110,8 @@ indexstoredb_index_create(const char *storePath, const char *databasePath,
   std::string errMsg;
   if (auto index =
           IndexSystem::create(storePath, databasePath, libProviderObj, delegate,
-                              readonly, listenToUnitEvents, llvm::None, errMsg)) {
+                              useExplicitOutputUnits, readonly,
+                              listenToUnitEvents, llvm::None, errMsg)) {
 
     if (wait)
       index->waitUntilDoneInitializing();
@@ -137,6 +139,28 @@ indexstoredb_load_indexstore_library(const char *dylibPath,
 void indexstoredb_index_poll_for_unit_changes_and_wait(indexstoredb_index_t index) {
   auto obj = (IndexStoreDBObject<std::shared_ptr<IndexSystem>> *)index;
   obj->value->pollForUnitChangesAndWait();
+}
+
+void indexstoredb_index_add_unit_out_file_paths(indexstoredb_index_t index,
+                                                const char *const *paths, size_t count,
+                                                bool waitForProcessing) {
+  auto obj = (IndexStoreDBObject<std::shared_ptr<IndexSystem>> *)index;
+  SmallVector<StringRef, 32> strVec;
+  strVec.reserve(count);
+  for (unsigned i = 0; i != count; ++i)
+    strVec.push_back(paths[i]);
+  return obj->value->addUnitOutFilePaths(strVec, waitForProcessing);
+}
+
+void indexstoredb_index_remove_unit_out_file_paths(indexstoredb_index_t index,
+                                                   const char *const *paths, size_t count,
+                                                   bool waitForProcessing) {
+  auto obj = (IndexStoreDBObject<std::shared_ptr<IndexSystem>> *)index;
+  SmallVector<StringRef, 32> strVec;
+  strVec.reserve(count);
+  for (unsigned i = 0; i != count; ++i)
+    strVec.push_back(paths[i]);
+  return obj->value->removeUnitOutFilePaths(strVec, waitForProcessing);
 }
 
 indexstoredb_delegate_event_kind_t

--- a/lib/Index/FileVisibilityChecker.h
+++ b/lib/Index/FileVisibilityChecker.h
@@ -41,12 +41,19 @@ class FileVisibilityChecker {
   std::unordered_map<db::IDCode, unsigned> MainFilesRefCount;
   std::unordered_map<db::IDCode, bool> UnitVisibilityCache;
 
+  std::unordered_set<db::IDCode> OutUnitFiles;
+  bool UseExplicitOutputUnits;
+
 public:
   FileVisibilityChecker(db::DatabaseRef dbase,
-                        std::shared_ptr<CanonicalPathCache> canonPathCache);
+                        std::shared_ptr<CanonicalPathCache> canonPathCache,
+                        bool useExplicitOutputUnits);
 
   void registerMainFiles(ArrayRef<StringRef> filePaths, StringRef productName);
   void unregisterMainFiles(ArrayRef<StringRef> filePaths, StringRef productName);
+
+  void addUnitOutFilePaths(ArrayRef<StringRef> filePaths);
+  void removeUnitOutFilePaths(ArrayRef<StringRef> filePaths);
 
   bool isUnitVisible(const db::UnitInfo &unitInfo, db::ReadTransaction &reader);
 };

--- a/lib/Index/IndexDatastore.cpp
+++ b/lib/Index/IndexDatastore.cpp
@@ -29,6 +29,7 @@
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/StringMap.h"
 #include "llvm/ADT/StringRef.h"
+#include "llvm/ADT/StringSet.h"
 #include "llvm/Support/ErrorHandling.h"
 #include "llvm/Support/Errc.h"
 #include "llvm/Support/FileSystem.h"
@@ -76,10 +77,16 @@ static dispatch_queue_t getGlobalQueueForUnitChanges() {
 namespace {
 
   class UnitMonitor;
+  class UnitProcessingSession;
 
 struct UnitEventInfo {
   IndexStore::UnitEvent::Kind kind;
   std::string name;
+  /// Whether this is an explicit enqueue of a dependency unit for processing, while `UseExplicitOutputUnits` is enabled.
+  bool isDependency;
+
+  UnitEventInfo(IndexStore::UnitEvent::Kind kind, std::string name, bool isDependency = false)
+  : kind(kind), name(std::move(name)), isDependency(isDependency) {}
 };
 
 struct DoneInitState {
@@ -95,6 +102,7 @@ struct PollUnitsState {
 class StoreUnitRepo : public std::enable_shared_from_this<StoreUnitRepo> {
   IndexStoreRef IdxStore;
   SymbolIndexRef SymIndex;
+  const bool UseExplicitOutputUnits;
   std::shared_ptr<IndexSystemDelegate> Delegate;
   std::shared_ptr<CanonicalPathCache> CanonPathCache;
 
@@ -108,12 +116,16 @@ class StoreUnitRepo : public std::enable_shared_from_this<StoreUnitRepo> {
   mutable llvm::sys::Mutex StateMtx;
   std::unordered_map<IDCode, std::shared_ptr<UnitMonitor>> UnitMonitorsByCode;
 
+  llvm::StringSet<> ExplicitOutputUnitsSet;
+
 public:
   StoreUnitRepo(IndexStoreRef IdxStore, SymbolIndexRef SymIndex,
+                bool useExplicitOutputUnits,
                 std::shared_ptr<IndexSystemDelegate> Delegate,
                 std::shared_ptr<CanonicalPathCache> canonPathCache)
   : IdxStore(IdxStore),
     SymIndex(std::move(SymIndex)),
+    UseExplicitOutputUnits(useExplicitOutputUnits),
     Delegate(std::move(Delegate)),
     CanonPathCache(std::move(canonPathCache)) {
     InitSemaphore = dispatch_semaphore_create(0);
@@ -123,6 +135,7 @@ public:
   }
 
   void onFilesChange(std::vector<UnitEventInfo> evts,
+                     std::shared_ptr<UnitProcessingSession> processSession,
                      function_ref<void(unsigned)> ReportCompleted,
                      function_ref<void()> DirectoryDeleted);
 
@@ -133,6 +146,11 @@ public:
 
   /// *For Testing* Poll for any changes to units and wait until they have been registered.
   void pollForUnitChangesAndWait();
+
+  std::shared_ptr<UnitProcessingSession> makeUnitProcessingSession();
+
+  void addUnitOutFilePaths(ArrayRef<StringRef> filePaths, bool waitForProcessing);
+  void removeUnitOutFilePaths(ArrayRef<StringRef> filePaths, bool waitForProcessing);
 
   void purgeStaleData();
 
@@ -148,7 +166,7 @@ public:
   void checkUnitContainingFileIsOutOfDate(StringRef file);
 
 private:
-  void registerUnit(StringRef UnitName);
+  void registerUnit(StringRef UnitName, std::shared_ptr<UnitProcessingSession> processSession);
   void removeUnit(StringRef UnitName);
 };
 
@@ -161,6 +179,7 @@ public:
             SymbolIndexRef SymIndex,
             std::shared_ptr<IndexSystemDelegate> Delegate,
             std::shared_ptr<CanonicalPathCache> CanonPathCache,
+            bool useExplicitOutputUnits,
             bool readonly,
             bool listenToUnitEvents,
             std::string &Error);
@@ -169,6 +188,10 @@ public:
   bool isUnitOutOfDate(StringRef unitOutputPath, ArrayRef<StringRef> dirtyFiles);
   bool isUnitOutOfDate(StringRef unitOutputPath, llvm::sys::TimePoint<> outOfDateModTime);
   void checkUnitContainingFileIsOutOfDate(StringRef file);
+
+  void addUnitOutFilePaths(ArrayRef<StringRef> filePaths, bool waitForProcessing);
+  void removeUnitOutFilePaths(ArrayRef<StringRef> filePaths, bool waitForProcessing);
+
   void purgeStaleData();
 
   /// *For Testing* Poll for any changes to units and wait until they have been registered.
@@ -223,7 +246,157 @@ public:
 // StoreUnitRepo
 //===----------------------------------------------------------------------===//
 
+namespace {
+
+/// A thread-safe deque object for UnitEventInfo objects.
+class UnitEventInfoDeque {
+  std::deque<UnitEventInfo> EventsDequeue;
+  mutable llvm::sys::Mutex StateMtx;
+
+public:
+  void addEvents(ArrayRef<UnitEventInfo> evts) {
+    sys::ScopedLock L(StateMtx);
+    EventsDequeue.insert(EventsDequeue.end(), evts.begin(), evts.end());
+  }
+
+  std::vector<UnitEventInfo> popFront(unsigned N) {
+    sys::ScopedLock L(StateMtx);
+    std::vector<UnitEventInfo> evts;
+    for (unsigned i = 0; i < N; ++i) {
+      if (EventsDequeue.empty())
+        break;
+      UnitEventInfo evt = EventsDequeue.front();
+      EventsDequeue.pop_front();
+      evts.push_back(std::move(evt));
+    }
+    return evts;
+  }
+
+  bool hasEnqueuedUnitDependency(StringRef unitName) const {
+    sys::ScopedLock L(StateMtx);
+    for (const auto &evt : EventsDequeue) {
+      if (evt.isDependency && evt.name == unitName)
+        return true;
+    }
+    return false;
+  }
+};
+
+/// Encapsulates state for processing a number of units and handles asynchronous (or synchronous for testing) scheduling.
+class UnitProcessingSession : public std::enable_shared_from_this<UnitProcessingSession> {
+  std::shared_ptr<UnitEventInfoDeque> Deque;
+  std::weak_ptr<StoreUnitRepo> WeakUnitRepo;
+  std::shared_ptr<IndexSystemDelegate> Delegate;
+
+  static const unsigned MAX_STORE_EVENTS_TO_PROCESS_PER_WORK_UNIT = 10;
+
+public:
+  UnitProcessingSession(std::shared_ptr<UnitEventInfoDeque> eventsDeque,
+                        std::weak_ptr<StoreUnitRepo> unitRepo,
+                        std::shared_ptr<IndexSystemDelegate> delegate)
+  : Deque(std::move(eventsDeque)), WeakUnitRepo(std::move(unitRepo)),
+    Delegate(std::move(delegate)) {
+  }
+
+  void process(std::vector<UnitEventInfo> evts, bool waitForProcessing) {
+    if (evts.empty()) {
+      return; // bail out early if there's no work.
+    }
+
+    enqueue(std::move(evts));
+
+    if (waitForProcessing) {
+      processUnitsAndWait();
+    } else {
+      processUnitsAsync();
+    }
+  }
+
+  /// Enqueue units for processing and return.
+  /// This should be used when `process()` has already be called on this session object.
+  void enqueue(std::vector<UnitEventInfo> evts) {
+    if (evts.empty())
+      return;
+    Delegate->processingAddedPending(evts.size());
+    Deque->addEvents(std::move(evts));
+  }
+
+  bool hasEnqueuedUnitDependency(StringRef unitName) const {
+    return Deque->hasEnqueuedUnitDependency(unitName);
+  }
+
+private:
+  void processUnitsAsync() {
+    auto session = shared_from_this();
+    auto onUnitChangeBlockImpl = ^{
+      // Pass registration events to be processed incrementally by the global serial queue.
+      // This allows intermixing processing of registration events from multiple workspaces.
+      session->processUnitEventsIncrementally(getGlobalQueueForUnitChanges());
+    };
+
+#if defined(__APPLE__)
+    // Create the block with QoS explicitly to ensure that the QoS from the indexstore callback can't affect the onFilesChange priority. This call may do a lot of I/O and we don't want to wedge the system by running at elevated priority.
+    dispatch_block_t onUnitChangeBlock = dispatch_block_create_with_qos_class(DISPATCH_BLOCK_INHERIT_QOS_CLASS, unitChangesQOS, 0, onUnitChangeBlockImpl);
+#else
+    // FIXME: https://bugs.swift.org/browse/SR-10319
+    auto onUnitChangeBlock = Block_copy(onUnitChangeBlockImpl);
+#endif
+    dispatch_async(getGlobalQueueForUnitChanges(), onUnitChangeBlock);
+    Block_release(onUnitChangeBlock);
+  }
+
+  /// Primarily used for testing.
+  void processUnitsAndWait() {
+    auto unitRepo = WeakUnitRepo.lock();
+    if (!unitRepo)
+      return;
+
+    while (true) {
+      std::vector<UnitEventInfo> evts = Deque->popFront(MAX_STORE_EVENTS_TO_PROCESS_PER_WORK_UNIT);
+      if (evts.empty()) {
+        break;
+      }
+
+      dispatch_sync(getGlobalQueueForUnitChanges(), ^{
+        unitRepo->onFilesChange(std::move(evts), shared_from_this(), [&](unsigned numCompleted){
+          Delegate->processingCompleted(numCompleted);
+        }, []{
+          // FIXME: the database should recover.
+        });
+      });
+    }
+  }
+
+  /// Enqueues asynchronous processing of the unit events in an incremental fashion.
+  /// Events are queued-up individually and the next event is enqueued only after
+  /// the current one has been processed.
+  void processUnitEventsIncrementally(dispatch_queue_t queue) {
+    std::vector<UnitEventInfo> poppedEvts = Deque->popFront(MAX_STORE_EVENTS_TO_PROCESS_PER_WORK_UNIT);
+    if (poppedEvts.empty())
+      return;
+    auto unitRepo = WeakUnitRepo.lock();
+    if (!unitRepo)
+      return;
+
+    auto session = shared_from_this();
+
+    unitRepo->onFilesChange(poppedEvts, session, [&](unsigned NumCompleted){
+      Delegate->processingCompleted(NumCompleted);
+    }, [&](){
+      // FIXME: the database should recover.
+    });
+
+    // Enqueue processing the rest of the events.
+    dispatch_async(queue, ^{
+      session->processUnitEventsIncrementally(queue);
+    });
+  }
+};
+
+} // end anonymous namespace
+
 void StoreUnitRepo::onFilesChange(std::vector<UnitEventInfo> evts,
+                                  std::shared_ptr<UnitProcessingSession> processSession,
                                   function_ref<void(unsigned)> ReportCompleted,
                                   function_ref<void()> DirectoryDeleted) {
 
@@ -248,17 +421,25 @@ void StoreUnitRepo::onFilesChange(std::vector<UnitEventInfo> evts,
     }
   };
 
+  auto shouldIgnore = [&](const UnitEventInfo &evt) -> bool {
+    if (!UseExplicitOutputUnits)
+      return false;
+    if (evt.isDependency)
+      return false;
+    return !ExplicitOutputUnitsSet.count(evt.name);
+  };
+
   for (const auto &evt : evts) {
     guardForMapFullError([&]{
       switch (evt.kind) {
       case IndexStore::UnitEvent::Kind::Added:
-        registerUnit(evt.name);
+      case IndexStore::UnitEvent::Kind::Modified:
+        if (!shouldIgnore(evt)) {
+          registerUnit(evt.name, processSession);
+        }
         break;
       case IndexStore::UnitEvent::Kind::Removed:
         removeUnit(evt.name);
-        break;
-      case IndexStore::UnitEvent::Kind::Modified:
-        registerUnit(evt.name);
         break;
       case IndexStore::UnitEvent::Kind::DirectoryDeleted:
         DirectoryDeleted();
@@ -286,7 +467,7 @@ void StoreUnitRepo::onFilesChange(std::vector<UnitEventInfo> evts,
   }
 }
 
-void StoreUnitRepo::registerUnit(StringRef unitName) {
+void StoreUnitRepo::registerUnit(StringRef unitName, std::shared_ptr<UnitProcessingSession> processSession) {
   std::string Error;
   auto optModTime = IdxStore->getUnitModificationTime(unitName, Error);
   if (!optModTime) {
@@ -315,6 +496,8 @@ void StoreUnitRepo::registerUnit(StringRef unitName) {
   Optional<StoreUnitInfo> StoreUnitInfoOpt;
   std::vector<CanonicalFilePath> UserFileDepends;
   std::vector<IDCode> UserUnitDepends;
+
+  SmallVector<std::string, 16> unitDependencies;
 
   // Returns true if an error occurred.
   auto importUnit = [&]() -> bool {
@@ -403,6 +586,7 @@ void StoreUnitRepo::registerUnit(StringRef unitName) {
         }
 
         case IndexUnitDependency::DependencyKind::Unit: {
+          unitDependencies.push_back(dep.Name);
           IDCode unitDepCode = unitImport.addUnitDependency(dep.Name);
           if (!dep.IsSystem)
             UserUnitDepends.push_back(unitDepCode);
@@ -439,6 +623,43 @@ void StoreUnitRepo::registerUnit(StringRef unitName) {
     }
     Delegate->processedStoreUnit(StoreUnitInfoOpt.getValue());
   }
+
+  if (UseExplicitOutputUnits) {
+    // Unit dependencies, like PCH/modules, are not included in the explicit list,
+    // make sure to process them as we find them.
+    // We do this after finishing processing the dependent unit to avoid nested write transactions.
+    std::vector<UnitEventInfo> unitsNeedingUpdate;
+    {
+      ReadTransaction reader(SymIndex->getDBase());
+
+      auto needsUpdate = [&](StringRef unitName) -> bool {
+        if (processSession->hasEnqueuedUnitDependency(unitName)) {
+          // Avoid enqueuing the same dependency from multiple dependents.
+          return false;
+        }
+        UnitInfo info = reader.getUnitInfo(unitName);
+        if (info.isInvalid()) {
+          return true; // not registered yet.
+        }
+        std::string error;
+        auto optModTime = IdxStore->getUnitModificationTime(unitName, error);
+        if (!optModTime) {
+          LOG_WARN_FUNC("error getting mod time for unit '" << unitName << "':" << error);
+          return false;
+        }
+        auto unitModTime = toTimePoint(optModTime.getValue());
+        return info.ModTime != unitModTime;
+      };
+
+      for (const auto &unitName : unitDependencies) {
+        if (needsUpdate(unitName)) {
+          unitsNeedingUpdate.push_back(UnitEventInfo(IndexStore::UnitEvent::Kind::Added, unitName, /*isDependency=*/true));
+        }
+      }
+    }
+    processSession->enqueue(std::move(unitsNeedingUpdate));
+  }
+
 
   if (*optIsSystem)
     return;
@@ -484,6 +705,42 @@ void StoreUnitRepo::removeUnit(StringRef unitName) {
   ImportTransaction import(SymIndex->getDBase());
   import.removeUnitData(unitName);
   import.commit();
+}
+
+void StoreUnitRepo::addUnitOutFilePaths(ArrayRef<StringRef> filePaths, bool waitForProcessing) {
+  std::vector<UnitEventInfo> unitEvts;
+  {
+    sys::ScopedLock L(StateMtx);
+    SmallString<128> nameBuf;
+    for (StringRef filePath : filePaths) {
+      nameBuf.clear();
+      IdxStore->getUnitNameFromOutputPath(filePath, nameBuf);
+      StringRef unitName = nameBuf.str();
+      ExplicitOutputUnitsSet.insert(unitName);
+      // It makes no difference for unit registration whether the kind is `Added` or `Modified`.
+      unitEvts.push_back(UnitEventInfo(IndexStore::UnitEvent::Kind::Added, unitName));
+    }
+  }
+  auto session = makeUnitProcessingSession();
+  session->process(std::move(unitEvts), waitForProcessing);
+}
+
+void StoreUnitRepo::removeUnitOutFilePaths(ArrayRef<StringRef> filePaths, bool waitForProcessing) {
+  // FIXME: This doesn't remove unit dependencies. Probably a task for `purgeStaleData`.
+  std::vector<UnitEventInfo> unitEvts;
+  {
+    sys::ScopedLock L(StateMtx);
+    SmallString<128> nameBuf;
+    for (StringRef filePath : filePaths) {
+      nameBuf.clear();
+      IdxStore->getUnitNameFromOutputPath(filePath, nameBuf);
+      StringRef unitName = nameBuf.str();
+      ExplicitOutputUnitsSet.erase(unitName);
+      unitEvts.push_back(UnitEventInfo(IndexStore::UnitEvent::Kind::Removed, unitName));
+    }
+  }
+  auto session = makeUnitProcessingSession();
+  session->process(std::move(unitEvts), waitForProcessing);
 }
 
 void StoreUnitRepo::purgeStaleData() {
@@ -554,15 +811,14 @@ void StoreUnitRepo::pollForUnitChangesAndWait() {
     pollUnitsState.knownUnits = std::move(foundUnits);
   }
 
-  Delegate->processingAddedPending(events.size());
+  auto session = makeUnitProcessingSession();
+  session->process(std::move(events), /*waitForProcessing=*/true);
+}
 
-  dispatch_sync(getGlobalQueueForUnitChanges(), ^{
-    onFilesChange(std::move(events), [&](unsigned numCompleted){
-      Delegate->processingCompleted(numCompleted);
-    }, []{
-      // FIXME: the database should recover.
-    });
-  });
+std::shared_ptr<UnitProcessingSession> StoreUnitRepo::makeUnitProcessingSession() {
+  return std::make_shared<UnitProcessingSession>(std::make_shared<UnitEventInfoDeque>(),
+                                                 shared_from_this(),
+                                                 Delegate);
 }
 
 std::shared_ptr<UnitMonitor> StoreUnitRepo::getUnitMonitor(IDCode unitCode) const {
@@ -803,65 +1059,11 @@ sys::TimePoint<> UnitMonitor::getModTimeForOutOfDateCheck(StringRef filePath) {
 // IndexDatastoreImpl
 //===----------------------------------------------------------------------===//
 
-static const unsigned MAX_STORE_EVENTS_TO_PROCESS_PER_WORK_UNIT = 10;
-
-namespace {
-/// A thread-safe deque object for UnitEventInfo objects.
-class UnitEventInfoDeque {
-  std::deque<UnitEventInfo> EventsDequeue;
-  mutable llvm::sys::Mutex StateMtx;
-
-public:
-  void addEvents(ArrayRef<UnitEventInfo> evts) {
-    sys::ScopedLock L(StateMtx);
-    EventsDequeue.insert(EventsDequeue.end(), evts.begin(), evts.end());
-  }
-
-  std::vector<UnitEventInfo> popFront(unsigned N) {
-    sys::ScopedLock L(StateMtx);
-    std::vector<UnitEventInfo> evts;
-    for (unsigned i = 0; i < N; ++i) {
-      if (EventsDequeue.empty())
-        break;
-      UnitEventInfo evt = EventsDequeue.front();
-      EventsDequeue.pop_front();
-      evts.push_back(std::move(evt));
-    }
-    return evts;
-  }
-};
-}
-
-/// Enqueues asynchronous processing of the unit events in an incremental fashion.
-/// Events are queued-up individually and the next event is enqueued only after
-/// the current one has been processed.
-static void processUnitEventsIncrementally(std::shared_ptr<UnitEventInfoDeque> evts,
-                                           std::weak_ptr<StoreUnitRepo> weakUnitRepo,
-                                           std::shared_ptr<IndexSystemDelegate> delegate,
-                                           dispatch_queue_t queue) {
-  std::vector<UnitEventInfo> poppedEvts = evts->popFront(MAX_STORE_EVENTS_TO_PROCESS_PER_WORK_UNIT);
-  if (poppedEvts.empty())
-    return;
-  auto UnitRepo = weakUnitRepo.lock();
-  if (!UnitRepo)
-    return;
-
-  UnitRepo->onFilesChange(poppedEvts, [&](unsigned NumCompleted){
-    delegate->processingCompleted(NumCompleted);
-  }, [&](){
-    // FIXME: the database should recover.
-  });
-
-  // Enqueue processing the rest of the events.
-  dispatch_async(queue, ^{
-    processUnitEventsIncrementally(evts, weakUnitRepo, delegate, queue);
-  });
-}
-
 bool IndexDatastoreImpl::init(IndexStoreRef idxStore,
                               SymbolIndexRef SymIndex,
                               std::shared_ptr<IndexSystemDelegate> Delegate,
                               std::shared_ptr<CanonicalPathCache> CanonPathCache,
+                              bool useExplicitOutputUnits,
                               bool readonly,
                               bool listenToUnitEvents,
                               std::string &Error) {
@@ -872,7 +1074,7 @@ bool IndexDatastoreImpl::init(IndexStoreRef idxStore,
   if (readonly)
     return false;
 
-  auto UnitRepo = std::make_shared<StoreUnitRepo>(this->IdxStore, SymIndex, Delegate, CanonPathCache);
+  auto UnitRepo = std::make_shared<StoreUnitRepo>(this->IdxStore, SymIndex, useExplicitOutputUnits, Delegate, CanonPathCache);
   std::weak_ptr<StoreUnitRepo> WeakUnitRepo = UnitRepo;
   auto eventsDeque = std::make_shared<UnitEventInfoDeque>();
   auto OnUnitsChange = [WeakUnitRepo, Delegate, eventsDeque](IndexStore::UnitEventNotification EventNote) {
@@ -894,24 +1096,8 @@ bool IndexDatastoreImpl::init(IndexStoreRef idxStore,
       evts.push_back(UnitEventInfo{evt.getKind(), evt.getUnitName()});
     }
 
-    Delegate->processingAddedPending(evts.size());
-    eventsDeque->addEvents(evts);
-
-    auto onUnitChangeBlockImpl = ^{
-      // Pass registration events to be processed incrementally by the global serial queue.
-      // This allows intermixing processing of registration events from multiple workspaces.
-      processUnitEventsIncrementally(eventsDeque, WeakUnitRepo, Delegate, getGlobalQueueForUnitChanges());
-    };
-
-#if defined(__APPLE__)
-    // Create the block with QoS explicitly to ensure that the QoS from the indexstore callback can't affect the onFilesChange priority. This call may do a lot of I/O and we don't want to wedge the system by running at elevated priority.
-    dispatch_block_t onUnitChangeBlock = dispatch_block_create_with_qos_class(DISPATCH_BLOCK_INHERIT_QOS_CLASS, unitChangesQOS, 0, onUnitChangeBlockImpl);
-#else
-    // FIXME: https://bugs.swift.org/browse/SR-10319
-    auto onUnitChangeBlock = Block_copy(onUnitChangeBlockImpl);
-#endif
-    dispatch_async(getGlobalQueueForUnitChanges(), onUnitChangeBlock);
-    Block_release(onUnitChangeBlock);
+    auto session = std::make_shared<UnitProcessingSession>(eventsDeque, WeakUnitRepo, Delegate);
+    session->process(std::move(evts), /*waitForProcessing=*/false);
   };
 
   if (listenToUnitEvents) {
@@ -952,6 +1138,14 @@ void IndexDatastoreImpl::checkUnitContainingFileIsOutOfDate(StringRef file) {
   UnitRepo->checkUnitContainingFileIsOutOfDate(file);
 }
 
+void IndexDatastoreImpl::addUnitOutFilePaths(ArrayRef<StringRef> filePaths, bool waitForProcessing) {
+  return UnitRepo->addUnitOutFilePaths(filePaths, waitForProcessing);
+}
+
+void IndexDatastoreImpl::removeUnitOutFilePaths(ArrayRef<StringRef> filePaths, bool waitForProcessing) {
+  return UnitRepo->removeUnitOutFilePaths(filePaths, waitForProcessing);
+}
+
 void IndexDatastoreImpl::purgeStaleData() {
   UnitRepo->purgeStaleData();
 }
@@ -969,11 +1163,13 @@ IndexDatastore::create(IndexStoreRef idxStore,
                        SymbolIndexRef SymIndex,
                        std::shared_ptr<IndexSystemDelegate> Delegate,
                        std::shared_ptr<CanonicalPathCache> CanonPathCache,
+                       bool useExplicitOutputUnits,
                        bool readonly,
                        bool listenToUnitEvents,
                        std::string &Error) {
   std::unique_ptr<IndexDatastoreImpl> Impl(new IndexDatastoreImpl());
-  bool Err = Impl->init(std::move(idxStore), std::move(SymIndex), std::move(Delegate), std::move(CanonPathCache), readonly, listenToUnitEvents, Error);
+  bool Err = Impl->init(std::move(idxStore), std::move(SymIndex), std::move(Delegate), std::move(CanonPathCache),
+                        useExplicitOutputUnits, readonly, listenToUnitEvents, Error);
   if (Err)
     return nullptr;
 
@@ -1002,6 +1198,14 @@ bool IndexDatastore::isUnitOutOfDate(StringRef unitOutputPath, sys::TimePoint<> 
 
 void IndexDatastore::checkUnitContainingFileIsOutOfDate(StringRef file) {
   return IMPL->checkUnitContainingFileIsOutOfDate(file);
+}
+
+void IndexDatastore::addUnitOutFilePaths(ArrayRef<StringRef> filePaths, bool waitForProcessing) {
+  return IMPL->addUnitOutFilePaths(filePaths, waitForProcessing);
+}
+
+void IndexDatastore::removeUnitOutFilePaths(ArrayRef<StringRef> filePaths, bool waitForProcessing) {
+  return IMPL->removeUnitOutFilePaths(filePaths, waitForProcessing);
 }
 
 void IndexDatastore::purgeStaleData() {

--- a/lib/Index/IndexDatastore.h
+++ b/lib/Index/IndexDatastore.h
@@ -40,6 +40,7 @@ public:
                                                 SymbolIndexRef SymIndex,
                                                 std::shared_ptr<IndexSystemDelegate> Delegate,
                                                 std::shared_ptr<CanonicalPathCache> CanonPathCache,
+                                                bool useExplicitOutputUnits,
                                                 bool readonly,
                                                 bool listenToUnitEvents,
                                                 std::string &Error);
@@ -52,6 +53,9 @@ public:
   /// Check whether any unit(s) containing \p file are out of date and if so,
   /// *synchronously* notify the delegate.
   void checkUnitContainingFileIsOutOfDate(StringRef file);
+
+  void addUnitOutFilePaths(ArrayRef<StringRef> filePaths, bool waitForProcessing);
+  void removeUnitOutFilePaths(ArrayRef<StringRef> filePaths, bool waitForProcessing);
 
   void purgeStaleData();
 

--- a/lib/Index/IndexSystem.cpp
+++ b/lib/Index/IndexSystem.cpp
@@ -117,6 +117,7 @@ public:
             StringRef dbasePath,
             std::shared_ptr<IndexStoreLibraryProvider> storeLibProvider,
             std::shared_ptr<IndexSystemDelegate> Delegate,
+            bool useExplicitOutputUnits,
             bool readonly, bool listenToUnitEvents,
             Optional<size_t> initialDBSize,
             std::string &Error);
@@ -129,6 +130,9 @@ public:
 
   void registerMainFiles(ArrayRef<StringRef> filePaths, StringRef productName);
   void unregisterMainFiles(ArrayRef<StringRef> filePaths, StringRef productName);
+
+  void addUnitOutFilePaths(ArrayRef<StringRef> filePaths, bool waitForProcessing);
+  void removeUnitOutFilePaths(ArrayRef<StringRef> filePaths, bool waitForProcessing);
 
   void purgeStaleData();
 
@@ -201,6 +205,7 @@ bool IndexSystemImpl::init(StringRef StorePath,
                            StringRef dbasePath,
                            std::shared_ptr<IndexStoreLibraryProvider> storeLibProvider,
                            std::shared_ptr<IndexSystemDelegate> Delegate,
+                           bool useExplicitOutputUnits,
                            bool readonly, bool listenToUnitEvents,
                            Optional<size_t> initialDBSize,
                            std::string &Error) {
@@ -232,7 +237,7 @@ bool IndexSystemImpl::init(StringRef StorePath,
 
   auto canonPathCache = std::make_shared<CanonicalPathCache>();
 
-  this->VisibilityChecker = std::make_shared<FileVisibilityChecker>(dbase, canonPathCache);
+  this->VisibilityChecker = std::make_shared<FileVisibilityChecker>(dbase, canonPathCache, useExplicitOutputUnits);
   this->SymIndex = std::make_shared<SymbolIndex>(dbase, idxStore, this->VisibilityChecker);
   this->PathIndex = std::make_shared<FilePathIndex>(dbase, idxStore, this->VisibilityChecker,
                                                     canonPathCache);
@@ -240,6 +245,7 @@ bool IndexSystemImpl::init(StringRef StorePath,
                                             this->SymIndex,
                                             this->DelegateWrap,
                                             canonPathCache,
+                                            useExplicitOutputUnits,
                                             readonly,
                                             listenToUnitEvents,
                                             Error);
@@ -271,6 +277,16 @@ void IndexSystemImpl::registerMainFiles(ArrayRef<StringRef> filePaths, StringRef
 
 void IndexSystemImpl::unregisterMainFiles(ArrayRef<StringRef> filePaths, StringRef productName) {
   return VisibilityChecker->unregisterMainFiles(filePaths, productName);
+}
+
+void IndexSystemImpl::addUnitOutFilePaths(ArrayRef<StringRef> filePaths, bool waitForProcessing) {
+  VisibilityChecker->addUnitOutFilePaths(filePaths);
+  IndexStore->addUnitOutFilePaths(filePaths, waitForProcessing);
+}
+
+void IndexSystemImpl::removeUnitOutFilePaths(ArrayRef<StringRef> filePaths, bool waitForProcessing) {
+  VisibilityChecker->removeUnitOutFilePaths(filePaths);
+  IndexStore->removeUnitOutFilePaths(filePaths, waitForProcessing);
 }
 
 void IndexSystemImpl::purgeStaleData() {
@@ -584,11 +600,13 @@ IndexSystem::create(StringRef StorePath,
                     StringRef dbasePath,
                     std::shared_ptr<IndexStoreLibraryProvider> storeLibProvider,
                     std::shared_ptr<IndexSystemDelegate> Delegate,
+                    bool useExplicitOutputUnits,
                     bool readonly, bool listenToUnitEvents,
                     Optional<size_t> initialDBSize,
                     std::string &Error) {
   std::unique_ptr<IndexSystemImpl> Impl(new IndexSystemImpl());
-  bool Err = Impl->init(StorePath, dbasePath, std::move(storeLibProvider), std::move(Delegate), readonly, listenToUnitEvents, initialDBSize, Error);
+  bool Err = Impl->init(StorePath, dbasePath, std::move(storeLibProvider), std::move(Delegate),
+                        useExplicitOutputUnits, readonly, listenToUnitEvents, initialDBSize, Error);
   if (Err)
     return nullptr;
 
@@ -625,6 +643,14 @@ void IndexSystem::registerMainFiles(ArrayRef<StringRef> filePaths, StringRef pro
 
 void IndexSystem::unregisterMainFiles(ArrayRef<StringRef> filePaths, StringRef productName) {
   return IMPL->unregisterMainFiles(filePaths, productName);
+}
+
+void IndexSystem::addUnitOutFilePaths(ArrayRef<StringRef> filePaths, bool waitForProcessing) {
+  return IMPL->addUnitOutFilePaths(filePaths, waitForProcessing);
+}
+
+void IndexSystem::removeUnitOutFilePaths(ArrayRef<StringRef> filePaths, bool waitForProcessing) {
+  return IMPL->removeUnitOutFilePaths(filePaths, waitForProcessing);
 }
 
 void IndexSystem::purgeStaleData() {


### PR DESCRIPTION
The benefits of this approach is that it allows the datastore to ignore leftover unit files so it can both improve performance and correctness by not taking into account stale data.

rdar://61899059