### PR TITLE
[5.3] Reduce memory usage in onFSEvent callback

### DIFF
--- a/lib/Index/IndexDatastore.cpp
+++ b/lib/Index/IndexDatastore.cpp
@@ -628,7 +628,7 @@ void StoreUnitRepo::onFSEvent(std::vector<std::string> changedParentPaths) {
     parentPathStrRefs.push_back(CanonicalFilePathRef::getAsCanonicalPath(path));
 
   struct OutOfDateCheck {
-    CanonicalFilePath FilePath;
+    std::string FilePath;
     sys::TimePoint<> ModTime;
     SmallVector<IDCode, 2> UnitCodes;
   };
@@ -638,7 +638,7 @@ void StoreUnitRepo::onFSEvent(std::vector<std::string> changedParentPaths) {
     ReadTransaction reader(SymIndex->getDBase());
     reader.findFilePathsWithParentPaths(parentPathStrRefs, [&](IDCode pathCode, CanonicalFilePathRef filePath) -> bool {
       auto modTime = UnitMonitor::getModTimeForOutOfDateCheck(filePath.getPath());
-      outOfDateChecks.push_back(OutOfDateCheck{filePath, modTime, {}});
+      outOfDateChecks.push_back(OutOfDateCheck{filePath.getPath().str(), modTime, {}});
       reader.foreachUnitContainingFile(pathCode, [&](ArrayRef<IDCode> unitCodes) -> bool {
         outOfDateChecks.back().UnitCodes.append(unitCodes.begin(), unitCodes.end());
         return true;
@@ -650,7 +650,7 @@ void StoreUnitRepo::onFSEvent(std::vector<std::string> changedParentPaths) {
   for (auto &check : outOfDateChecks) {
     for (IDCode unitCode : check.UnitCodes) {
       if (auto monitor = getUnitMonitor(unitCode)) {
-        monitor->checkForOutOfDate(check.ModTime, check.FilePath.getPath());
+        monitor->checkForOutOfDate(check.ModTime, check.FilePath);
       }
     }
   }

--- a/lib/Index/IndexDatastore.cpp
+++ b/lib/Index/IndexDatastore.cpp
@@ -628,9 +628,9 @@ void StoreUnitRepo::onFSEvent(std::vector<std::string> changedParentPaths) {
     parentPathStrRefs.push_back(CanonicalFilePathRef::getAsCanonicalPath(path));
 
   struct OutOfDateCheck {
-    std::shared_ptr<UnitMonitor> Monitor;
-    sys::TimePoint<> ModTime;
     CanonicalFilePath FilePath;
+    sys::TimePoint<> ModTime;
+    SmallVector<IDCode, 2> UnitCodes;
   };
 
   std::vector<OutOfDateCheck> outOfDateChecks;
@@ -638,12 +638,9 @@ void StoreUnitRepo::onFSEvent(std::vector<std::string> changedParentPaths) {
     ReadTransaction reader(SymIndex->getDBase());
     reader.findFilePathsWithParentPaths(parentPathStrRefs, [&](IDCode pathCode, CanonicalFilePathRef filePath) -> bool {
       auto modTime = UnitMonitor::getModTimeForOutOfDateCheck(filePath.getPath());
+      outOfDateChecks.push_back(OutOfDateCheck{filePath, modTime, {}});
       reader.foreachUnitContainingFile(pathCode, [&](ArrayRef<IDCode> unitCodes) -> bool {
-        for (IDCode unitCode : unitCodes) {
-          if (auto monitor = getUnitMonitor(unitCode)) {
-            outOfDateChecks.push_back(OutOfDateCheck{monitor, modTime, filePath});
-          }
-        }
+        outOfDateChecks.back().UnitCodes.append(unitCodes.begin(), unitCodes.end());
         return true;
       });
       return true;
@@ -651,7 +648,11 @@ void StoreUnitRepo::onFSEvent(std::vector<std::string> changedParentPaths) {
   }
   // We collect and call later to avoid nested read transactions.
   for (auto &check : outOfDateChecks) {
-    check.Monitor->checkForOutOfDate(check.ModTime, check.FilePath.getPath());
+    for (IDCode unitCode : check.UnitCodes) {
+      if (auto monitor = getUnitMonitor(unitCode)) {
+        monitor->checkForOutOfDate(check.ModTime, check.FilePath.getPath());
+      }
+    }
   }
 }
 


### PR DESCRIPTION
Cherry-pick #84 and #86 to 5.3

----

Store the path of the file triggering an out-of-date check once in the
array of checks, rather than once for every unit. For headers included
by many unit files this was causing us to use several GB just for this
single std::vector.

rdar://53835770

