### PR TITLE
Additional memory savings for onFSEvent

### DIFF
--- a/lib/Index/IndexDatastore.cpp
+++ b/lib/Index/IndexDatastore.cpp
@@ -890,7 +890,7 @@ void StoreUnitRepo::onFSEvent(std::vector<std::string> changedParentPaths) {
     parentPathStrRefs.push_back(CanonicalFilePathRef::getAsCanonicalPath(path));
 
   struct OutOfDateCheck {
-    CanonicalFilePath FilePath;
+    std::string FilePath;
     sys::TimePoint<> ModTime;
     SmallVector<IDCode, 2> UnitCodes;
   };
@@ -900,7 +900,7 @@ void StoreUnitRepo::onFSEvent(std::vector<std::string> changedParentPaths) {
     ReadTransaction reader(SymIndex->getDBase());
     reader.findFilePathsWithParentPaths(parentPathStrRefs, [&](IDCode pathCode, CanonicalFilePathRef filePath) -> bool {
       auto modTime = UnitMonitor::getModTimeForOutOfDateCheck(filePath.getPath());
-      outOfDateChecks.push_back(OutOfDateCheck{filePath, modTime, {}});
+      outOfDateChecks.push_back(OutOfDateCheck{filePath.getPath().str(), modTime, {}});
       reader.foreachUnitContainingFile(pathCode, [&](ArrayRef<IDCode> unitCodes) -> bool {
         outOfDateChecks.back().UnitCodes.append(unitCodes.begin(), unitCodes.end());
         return true;
@@ -912,7 +912,7 @@ void StoreUnitRepo::onFSEvent(std::vector<std::string> changedParentPaths) {
   for (auto &check : outOfDateChecks) {
     for (IDCode unitCode : check.UnitCodes) {
       if (auto monitor = getUnitMonitor(unitCode)) {
-        monitor->checkForOutOfDate(check.ModTime, check.FilePath.getPath());
+        monitor->checkForOutOfDate(check.ModTime, check.FilePath);
       }
     }
   }


### PR DESCRIPTION
Argyrios suggested switching to std::string, since CanonicalFilePath
contains a SmallString<128>.

rdar://53835770