### PR TITLE
[IndexDatastore] Provide an option to disable the file-out-of-date notification mechanism

### DIFF
--- a/include/IndexStoreDB/Index/IndexSystem.h
+++ b/include/IndexStoreDB/Index/IndexSystem.h
@@ -48,6 +48,7 @@ public:
                                              std::shared_ptr<IndexSystemDelegate> Delegate,
                                              bool useExplicitOutputUnits,
                                              bool readonly,
+                                             bool enableOutOfDateFileWatching,
                                              bool listenToUnitEvents,
                                              Optional<size_t> initialDBSize,
                                              std::string &Error);

--- a/lib/CIndexStoreDB/CIndexStoreDB.cpp
+++ b/lib/CIndexStoreDB/CIndexStoreDB.cpp
@@ -108,10 +108,14 @@ indexstoredb_index_create(const char *storePath, const char *databasePath,
   auto libProviderObj = std::make_shared<BlockIndexStoreLibraryProvider>(libProvider);
 
   std::string errMsg;
+  // `enableOutOfDateFileWatching` is set to `false` by default because the
+  // out-of-date notifications are not exposed at all, so this notification
+  // mechanism is taking CPU & memory unnecessarily.
   if (auto index =
           IndexSystem::create(storePath, databasePath, libProviderObj, delegate,
                               useExplicitOutputUnits, readonly,
-                              listenToUnitEvents, llvm::None, errMsg)) {
+                              /*enableOutOfDateFileWatching=*/false, listenToUnitEvents,
+                              llvm::None, errMsg)) {
 
     if (wait)
       index->waitUntilDoneInitializing();

--- a/lib/Index/IndexDatastore.h
+++ b/lib/Index/IndexDatastore.h
@@ -42,6 +42,7 @@ public:
                                                 std::shared_ptr<CanonicalPathCache> CanonPathCache,
                                                 bool useExplicitOutputUnits,
                                                 bool readonly,
+                                                bool enableOutOfDateFileWatching,
                                                 bool listenToUnitEvents,
                                                 std::string &Error);
 

--- a/lib/Index/IndexSystem.cpp
+++ b/lib/Index/IndexSystem.cpp
@@ -117,8 +117,8 @@ public:
             StringRef dbasePath,
             std::shared_ptr<IndexStoreLibraryProvider> storeLibProvider,
             std::shared_ptr<IndexSystemDelegate> Delegate,
-            bool useExplicitOutputUnits,
-            bool readonly, bool listenToUnitEvents,
+            bool useExplicitOutputUnits, bool readonly,
+            bool enableOutOfDateFileWatching, bool listenToUnitEvents,
             Optional<size_t> initialDBSize,
             std::string &Error);
 
@@ -205,8 +205,8 @@ bool IndexSystemImpl::init(StringRef StorePath,
                            StringRef dbasePath,
                            std::shared_ptr<IndexStoreLibraryProvider> storeLibProvider,
                            std::shared_ptr<IndexSystemDelegate> Delegate,
-                           bool useExplicitOutputUnits,
-                           bool readonly, bool listenToUnitEvents,
+                           bool useExplicitOutputUnits, bool readonly,
+                           bool enableOutOfDateFileWatching, bool listenToUnitEvents,
                            Optional<size_t> initialDBSize,
                            std::string &Error) {
   this->StorePath = StorePath;
@@ -247,6 +247,7 @@ bool IndexSystemImpl::init(StringRef StorePath,
                                             canonPathCache,
                                             useExplicitOutputUnits,
                                             readonly,
+                                            enableOutOfDateFileWatching,
                                             listenToUnitEvents,
                                             Error);
 
@@ -600,13 +601,15 @@ IndexSystem::create(StringRef StorePath,
                     StringRef dbasePath,
                     std::shared_ptr<IndexStoreLibraryProvider> storeLibProvider,
                     std::shared_ptr<IndexSystemDelegate> Delegate,
-                    bool useExplicitOutputUnits,
-                    bool readonly, bool listenToUnitEvents,
+                    bool useExplicitOutputUnits, bool readonly,
+                    bool enableOutOfDateFileWatching, bool listenToUnitEvents,
                     Optional<size_t> initialDBSize,
                     std::string &Error) {
   std::unique_ptr<IndexSystemImpl> Impl(new IndexSystemImpl());
   bool Err = Impl->init(StorePath, dbasePath, std::move(storeLibProvider), std::move(Delegate),
-                        useExplicitOutputUnits, readonly, listenToUnitEvents, initialDBSize, Error);
+                        useExplicitOutputUnits, readonly,
+                        enableOutOfDateFileWatching, listenToUnitEvents,
+                        initialDBSize, Error);
   if (Err)
     return nullptr;
 


### PR DESCRIPTION
This mechanism is disabled by default for the CIndexStoreDB API because the out-of-date notifications are not exposed at all, so the mechanism is taking CPU & memory unnecessarily.