### PR TITLE
Implicit use of <cstdint.h> fails with Clang 10

### DIFF
--- a/include/IndexStoreDB/Database/IDCode.h
+++ b/include/IndexStoreDB/Database/IDCode.h
@@ -14,6 +14,7 @@
 #define INDEXSTOREDB_SKDATABASE_IDCODE_H
 
 #include <functional>
+#include <cstdint>
 
 namespace IndexStoreDB {
 namespace db {


### PR DESCRIPTION
Discovered this while building under Linux