### PR TITLE
build: add CIndexStoreDB to the interface includes

### DIFF
--- a/Sources/IndexStoreDB/CMakeLists.txt
+++ b/Sources/IndexStoreDB/CMakeLists.txt
@@ -15,7 +15,7 @@ add_library(IndexStoreDB
   Symbol.swift)
 set_target_properties(IndexStoreDB PROPERTIES
   Swift_MODULE_DIRECTORY ${CMAKE_BINARY_DIR}/swift
-  INTERFACE_INCLUDE_DIRECTORIES ${CMAKE_BINARY_DIR}/swift)
+  INTERFACE_INCLUDE_DIRECTORIES "${CMAKE_BINARY_DIR}/swift")
 target_link_libraries(IndexStoreDB PRIVATE
   Foundation
   CIndexStoreDB)

--- a/Sources/IndexStoreDB/IndexStoreDB.swift
+++ b/Sources/IndexStoreDB/IndexStoreDB.swift
@@ -10,6 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+@_implementationOnly
 import CIndexStoreDB
 
 // For `strdup`
@@ -25,7 +26,7 @@ import Darwin.POSIX
 public final class IndexStoreDB {
 
   let delegate: IndexDelegate?
-  let impl: indexstoredb_index_t
+  let impl: UnsafeMutableRawPointer // indexstoredb_index_t
 
   /// Create or open an IndexStoreDB at the givin `databasePath`.
   ///
@@ -51,7 +52,7 @@ public final class IndexStoreDB {
   ) throws {
     self.delegate = delegate
 
-    let libProviderFunc = { (cpath: UnsafePointer<Int8>) -> indexstoredb_indexstore_library_t? in
+    let libProviderFunc: indexstore_library_provider_t = { (cpath: UnsafePointer<Int8>) -> indexstoredb_indexstore_library_t? in
       return library?.library
     }
 
@@ -294,7 +295,7 @@ public protocol IndexStoreLibraryProvider {
 }
 
 public class IndexStoreLibrary {
-  let library: indexstoredb_indexstore_library_t
+  let library: UnsafeMutableRawPointer // indexstoredb_indexstore_library_t
 
   public init(dylibPath: String) throws {
     var error: indexstoredb_error_t? = nil

--- a/Sources/IndexStoreDB/IndexStoreDBError.swift
+++ b/Sources/IndexStoreDB/IndexStoreDBError.swift
@@ -10,7 +10,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+@_implementationOnly
 import CIndexStoreDB
+
 import protocol Foundation.LocalizedError
 
 public enum IndexStoreDBError: Error {

--- a/Sources/IndexStoreDB/Symbol.swift
+++ b/Sources/IndexStoreDB/Symbol.swift
@@ -10,6 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+@_implementationOnly
 import CIndexStoreDB
 
 public enum IndexSymbolKind: Hashable {

--- a/Sources/IndexStoreDB/SymbolLocation.swift
+++ b/Sources/IndexStoreDB/SymbolLocation.swift
@@ -10,6 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+@_implementationOnly
 import CIndexStoreDB
 
 public struct SymbolLocation: Equatable {
@@ -44,7 +45,7 @@ extension SymbolLocation: CustomStringConvertible {
 // MARK: CIndexStoreDB conversions
 
 extension SymbolLocation {
-  public init(_ loc: indexstoredb_symbol_location_t) {
+  internal init(_ loc: indexstoredb_symbol_location_t) {
     path = String(cString: indexstoredb_symbol_location_path(loc))
     moduleName = String(cString: indexstoredb_symbol_location_module_name(loc))
     isSystem = indexstoredb_symbol_location_is_system(loc)

--- a/Sources/IndexStoreDB/SymbolOccurrence.swift
+++ b/Sources/IndexStoreDB/SymbolOccurrence.swift
@@ -10,6 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+@_implementationOnly
 import CIndexStoreDB
 
 public struct SymbolOccurrence: Equatable {
@@ -60,7 +61,7 @@ public struct SymbolRelation: Equatable {
 extension SymbolOccurrence {
 
   /// Note: `value` is expected to be passed +1.
-  init(_ value: indexstoredb_symbol_occurrence_t) {
+  internal init(_ value: indexstoredb_symbol_occurrence_t) {
     var relations: [SymbolRelation] = []
     indexstoredb_symbol_occurrence_relations(value) { relation in
       relations.append(SymbolRelation(relation))
@@ -76,7 +77,7 @@ extension SymbolOccurrence {
 }
 
 extension SymbolRelation {
-  public init(_ value: indexstoredb_symbol_relation_t) {
+  internal init(_ value: indexstoredb_symbol_relation_t) {
     self.init(
       symbol: Symbol(indexstoredb_symbol_relation_get_symbol(value)),
       roles: SymbolRole(rawValue: indexstoredb_symbol_relation_get_roles(value)))

--- a/Sources/IndexStoreDB/SymbolRole.swift
+++ b/Sources/IndexStoreDB/SymbolRole.swift
@@ -10,6 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+@_implementationOnly
 import CIndexStoreDB
 
 public struct SymbolRole: OptionSet, Hashable {
@@ -51,7 +52,7 @@ public struct SymbolRole: OptionSet, Hashable {
     self.rawValue = rawValue
   }
 
-  public init(rawValue: indexstoredb_symbol_role_t) {
+  internal init(rawValue: indexstoredb_symbol_role_t) {
     self.rawValue = UInt64(rawValue.rawValue)
   }
 }


### PR DESCRIPTION
This include path is needed to build SourceKit-LSP.