### PR TITLE
[tsan] Fix a race during processUnitsAndWait()

### DIFF
--- a/include/IndexStoreDB/Index/IndexSystem.h
+++ b/include/IndexStoreDB/Index/IndexSystem.h
@@ -50,10 +50,9 @@ public:
                                              bool readonly,
                                              bool enableOutOfDateFileWatching,
                                              bool listenToUnitEvents,
+                                             bool waitUntilDoneInitializing,
                                              Optional<size_t> initialDBSize,
                                              std::string &Error);
-
-  void waitUntilDoneInitializing();
 
   bool isUnitOutOfDate(StringRef unitOutputPath, ArrayRef<StringRef> dirtyFiles);
   bool isUnitOutOfDate(StringRef unitOutputPath, llvm::sys::TimePoint<> outOfDateModTime);

--- a/lib/CIndexStoreDB/CIndexStoreDB.cpp
+++ b/lib/CIndexStoreDB/CIndexStoreDB.cpp
@@ -114,11 +114,8 @@ indexstoredb_index_create(const char *storePath, const char *databasePath,
   if (auto index =
           IndexSystem::create(storePath, databasePath, libProviderObj, delegate,
                               useExplicitOutputUnits, readonly,
-                              /*enableOutOfDateFileWatching=*/false, listenToUnitEvents,
+                              /*enableOutOfDateFileWatching=*/false, listenToUnitEvents, wait,
                               llvm::None, errMsg)) {
-
-    if (wait)
-      index->waitUntilDoneInitializing();
 
     return make_object(index);
 

--- a/lib/Index/IndexDatastore.h
+++ b/lib/Index/IndexDatastore.h
@@ -44,9 +44,8 @@ public:
                                                 bool readonly,
                                                 bool enableOutOfDateFileWatching,
                                                 bool listenToUnitEvents,
+                                                bool waitUntilDoneInitializing,
                                                 std::string &Error);
-
-  void waitUntilDoneInitializing();
 
   bool isUnitOutOfDate(StringRef unitOutputPath, ArrayRef<StringRef> dirtyFiles);
   bool isUnitOutOfDate(StringRef unitOutputPath, llvm::sys::TimePoint<> outOfDateModTime);


### PR DESCRIPTION
After we added processUnitsAndWait() as a separte entry point that
ultimately called the onFilesChange() method, it created a race on the
DoneInitState, which was accessed directly in the unit event callback
before jumping to the unit processing queue. Simplify that logic and fix
the race by using processUnitsAndWait() during initialization if we
desire waiting, and get rid of DoneInitState.

The previous approach was more flexible about allowing you to wait at an
arbitrary point after creating the IndexDatastore, but in practice we
were not using that ability, and it made it harder to understand the
synchronization required.