### PR TITLE
ISDBTibs Process.swift: move Pipe readDataToEndOfFile() before Proces…

### DIFF
--- a/Sources/ISDBTibs/Process.swift
+++ b/Sources/ISDBTibs/Process.swift
@@ -45,13 +45,13 @@ extension Process {
       p.launch()
     }
 
+    let data = out.fileHandleForReading.readDataToEndOfFile()
     p.waitUntilExit()
 
     if p.terminationReason != .exit || p.terminationStatus != 0 {
       throw TibsProcessError.nonZeroExit(p.terminationReason, p.terminationStatus)
     }
 
-    let data = out.fileHandleForReading.readDataToEndOfFile()
     guard let str = String(data: data, encoding: .utf8) else {
       throw TibsProcessError.invalidUTF8Output(data)
     }


### PR DESCRIPTION
…s waitUntilExit() to avoid hangs on macOS (see https://stackoverflow.com/questions/33423993/hanging-nstask-using-waituntilexit)