### PR TITLE
[cmake] Fix linking of Foundation and dispatch on Darwin

### DIFF
--- a/Sources/IndexStoreDB/CMakeLists.txt
+++ b/Sources/IndexStoreDB/CMakeLists.txt
@@ -17,8 +17,11 @@ set_target_properties(IndexStoreDB PROPERTIES
   Swift_MODULE_DIRECTORY ${CMAKE_BINARY_DIR}/swift
   INTERFACE_INCLUDE_DIRECTORIES "${CMAKE_BINARY_DIR}/swift")
 target_link_libraries(IndexStoreDB PRIVATE
-  Foundation
   CIndexStoreDB)
+if(NOT CMAKE_SYSTEM_NAME STREQUAL Darwin)
+  target_link_libraries(IndexStoreDB PRIVATE
+    Foundation)
+endif()
 
 get_swift_host_arch(swift_arch)
 install(TARGETS IndexStoreDB

--- a/lib/CIndexStoreDB/CMakeLists.txt
+++ b/lib/CIndexStoreDB/CMakeLists.txt
@@ -5,10 +5,13 @@ target_compile_options(CIndexStoreDB PRIVATE
 target_include_directories(CIndexStoreDB PUBLIC
   ${PROJECT_SOURCE_DIR}/include/CIndexStoreDB)
 target_link_libraries(CIndexStoreDB PRIVATE
-  dispatch
   LLVMSupport)
 target_link_libraries(CIndexStoreDB PUBLIC
   Index)
+if(NOT CMAKE_SYSTEM_NAME STREQUAL Darwin)
+  target_link_libraries(CIndexStoreDB PRIVATE
+    dispatch)
+endif()
 
 if(NOT BUILD_SHARED_LIBS)
   set_property(GLOBAL APPEND PROPERTY IndexStoreDB_EXPORTS CIndexStoreDB)

--- a/lib/Database/CMakeLists.txt
+++ b/lib/Database/CMakeLists.txt
@@ -10,9 +10,12 @@ target_compile_options(Database PRIVATE
 target_include_directories(Database PRIVATE
   include)
 target_link_libraries(Database PRIVATE
-  dispatch
   Core
   LLVMSupport)
+if(NOT CMAKE_SYSTEM_NAME STREQUAL Darwin)
+  target_link_libraries(Database PRIVATE
+    dispatch)
+endif()
 
 if(NOT BUILD_SHARED_LIBS)
   set_property(GLOBAL APPEND PROPERTY IndexStoreDB_EXPORTS Database)

--- a/lib/Index/CMakeLists.txt
+++ b/lib/Index/CMakeLists.txt
@@ -12,9 +12,12 @@ target_compile_options(Index PRIVATE
 target_include_directories(Index PUBLIC
   ${PROJECT_SOURCE_DIR}/include)
 target_link_libraries(Index PRIVATE
-  dispatch
   Database
   LLVMSupport)
+if(NOT CMAKE_SYSTEM_NAME STREQUAL Darwin)
+  target_link_libraries(Index PRIVATE
+    dispatch)
+endif()
 
 if(NOT BUILD_SHARED_LIBS)
   set_property(GLOBAL APPEND PROPERTY IndexStoreDB_EXPORTS Index)

--- a/lib/Support/CMakeLists.txt
+++ b/lib/Support/CMakeLists.txt
@@ -11,8 +11,11 @@ target_compile_options(Support PRIVATE
 target_include_directories(Support PRIVATE
   include)
 target_link_libraries(Support PRIVATE
-  dispatch
   LLVMSupport)
+if(NOT CMAKE_SYSTEM_NAME STREQUAL Darwin)
+  target_link_libraries(Support PRIVATE
+    dispatch)
+endif()
 
 if(NOT BUILD_SHARED_LIBS)
   set_property(GLOBAL APPEND PROPERTY IndexStoreDB_EXPORTS Support)


### PR DESCRIPTION
These come from the SDK and we rely on autolinking. Fixes incorrect
-ldispatch and -lFoundation linker flags.