### PR TITLE
Replace swift-clang link with llvm-project

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # IndexStoreDB
 
-IndexStoreDB is a source code indexing library. It provides a composable and efficient query API for looking up source code symbols, symbol occurrences, and relations. IndexStoreDB uses the libIndexStore library, which lives in [llvm-project](https://github.com/apple/llvm-project/tree/apple/master/clang/lib/Index), for reading raw index data. Raw index data can be produced by compilers such as Clang and Swift using the `-index-store-path` option. IndexStoreDB enables efficiently querying this data by maintaining acceleration tables in a key-value database built with [LMDB](http://www.lmdb.tech/).
+IndexStoreDB is a source code indexing library. It provides a composable and efficient query API for looking up source code symbols, symbol occurrences, and relations. IndexStoreDB uses the libIndexStore library, which lives in [llvm-project](https://github.com/apple/llvm-project/tree/apple/master/clang/tools/IndexStore), for reading raw index data. Raw index data can be produced by compilers such as Clang and Swift using the `-index-store-path` option. IndexStoreDB enables efficiently querying this data by maintaining acceleration tables in a key-value database built with [LMDB](http://www.lmdb.tech/).
 
 IndexStoreDB's data model is derived from libIndexStore. For more information about libIndexStore, and producing raw indexing data, see the [Indexing While Building](https://docs.google.com/document/d/1cH2sTpgSnJZCkZtJl1aY-rzy4uGPcrI-6RrUpdATO2Q/) whitepaper.
 


### PR DESCRIPTION
`swift-clang` repository is now archived and is no longer active.