### PR TITLE
Add the ability to re-wrap an existing index

### DIFF
--- a/Sources/IndexStoreDB/IndexDelegate.swift
+++ b/Sources/IndexStoreDB/IndexDelegate.swift
@@ -10,6 +10,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+@_implementationOnly import CIndexStoreDB
+
 /// Delegate for index events.
 public protocol IndexDelegate: AnyObject {
 
@@ -18,4 +20,20 @@ public protocol IndexDelegate: AnyObject {
 
   /// The index finished processing `count` unit files.
   func processingCompleted(_ count: Int)
+}
+
+extension IndexDelegate {
+  internal func handleEvent(_ event: indexstoredb_delegate_event_t) {
+    let kind = indexstoredb_delegate_event_get_kind(event)
+    switch kind {
+    case INDEXSTOREDB_EVENT_PROCESSING_ADDED_PENDING:
+      let count = indexstoredb_delegate_event_get_count(event)
+      self.processingAddedPending(Int(count))
+    case INDEXSTOREDB_EVENT_PROCESSING_COMPLETED:
+      let count = indexstoredb_delegate_event_get_count(event)
+      self.processingCompleted(Int(count))
+    default:
+      return
+    }
+  }
 }

--- a/include/CIndexStoreDB/CIndexStoreDB.h
+++ b/include/CIndexStoreDB/CIndexStoreDB.h
@@ -156,6 +156,11 @@ indexstoredb_index_create(const char * _Nonnull storePath,
                   bool listenToUnitEvents,
                   indexstoredb_error_t _Nullable * _Nullable);
 
+/// Add an additional delegate to the given index.
+INDEXSTOREDB_PUBLIC void
+indexstoredb_index_add_delegate(_Nonnull indexstoredb_index_t index,
+                                _Nonnull indexstoredb_delegate_event_receiver_t delegate);
+
 /// Creates an indexstore library for the given library.
 ///
 /// The resulting object must be released using \c indexstoredb_release.

--- a/include/CIndexStoreDB/CIndexStoreDB_Internal.h
+++ b/include/CIndexStoreDB/CIndexStoreDB_Internal.h
@@ -14,6 +14,7 @@
 #define INDEXSTOREDB_INTERNAL_H
 
 #include "llvm/ADT/IntrusiveRefCntPtr.h"
+#include <utility>
 
 namespace IndexStoreDB {
 namespace internal {

--- a/include/CIndexStoreDB/CIndexStoreDB_Internal.h
+++ b/include/CIndexStoreDB/CIndexStoreDB_Internal.h
@@ -1,0 +1,44 @@
+/*===--- CIndexStoreDB.h ------------------------------------------*- C -*-===//
+ *
+ * This source file is part of the Swift.org open source project
+ *
+ * Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+ * Licensed under Apache License v2.0 with Runtime Library Exception
+ *
+ * See https://swift.org/LICENSE.txt for license information
+ * See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+ *
+ *===----------------------------------------------------------------------===*/
+
+#ifndef INDEXSTOREDB_INTERNAL_H
+#define INDEXSTOREDB_INTERNAL_H
+
+#include "llvm/ADT/IntrusiveRefCntPtr.h"
+
+namespace IndexStoreDB {
+namespace internal {
+
+class ObjectBase : public llvm::ThreadSafeRefCountedBase<ObjectBase> {
+public:
+    virtual ~ObjectBase();
+};
+
+template <typename T>
+class Object: public ObjectBase {
+public:
+    T value;
+
+    Object(T value) : value(std::move(value)) {}
+};
+
+template <typename T>
+static inline Object<T> *make_object(const T &value) {
+  auto obj = new Object<T>(value);
+  obj->Retain();
+  return obj;
+}
+
+} // namespace internal
+} // namespace IndexStoreDB
+
+#endif // INDEXSTOREDB_INTERNAL_H

--- a/include/IndexStoreDB/Index/IndexSystem.h
+++ b/include/IndexStoreDB/Index/IndexSystem.h
@@ -84,6 +84,8 @@ public:
   void dumpProviderFileAssociations(raw_ostream &OS);
   void dumpProviderFileAssociations();
 
+  void addDelegate(std::shared_ptr<IndexSystemDelegate> Delegate);
+
   //===--------------------------------------------------------------------===//
   // Queries
   //===--------------------------------------------------------------------===//


### PR DESCRIPTION
Add hooks to add a new delegate to an existing IndexSystem and wrap it with a fresh IndexStoreDB.