### PR TITLE
[Database] Make the database path unique to the specific lmdb wrapper instance

### DIFF
--- a/Tests/INPUTS/SingleUnit/main.c
+++ b/Tests/INPUTS/SingleUnit/main.c
@@ -1,0 +1,1 @@
+void test() {}

--- a/Tests/INPUTS/SingleUnit/project.json
+++ b/Tests/INPUTS/SingleUnit/project.json
@@ -1,0 +1,1 @@
+{"sources": ["main.c"]}

--- a/Tests/IndexStoreDBTests/IndexStoreDBTests.swift
+++ b/Tests/IndexStoreDBTests/IndexStoreDBTests.swift
@@ -72,7 +72,37 @@ final class IndexStoreDBTests: XCTestCase {
     }
   }
 
-  static var allTests = [
-    ("testErrors", testErrors),
-    ]
+  func testSymlinkedDBPaths() throws {
+    let toolchain = TibsToolchain.testDefault
+    let libIndexStore = try! IndexStoreLibrary(dylibPath: toolchain.libIndexStore.path)
+
+    // This tests against a crash that was manifesting when creating separate `IndexStoreDB` instances against 2 DB paths
+    // that resolve to the same underlying directory (e.g. they were symlinked).
+    // It runs a number of iterations though it was not guaranteed that the issue would hit within a specific number
+    // of iterations, only that at *some* point, if you let it run indefinitely, it could trigger.
+    let iterations = 100
+
+    let indexStorePath: String
+    do {
+      // Don't care about specific index data, just want an index store directory containing *something*.
+      guard let ws = try staticTibsTestWorkspace(name: "SingleUnit") else { return }
+      try ws.buildAndIndex()
+      indexStorePath =  ws.builder.indexstore.path
+    }
+
+    let fileMgr = FileManager.default
+    let mainDBPath = tmp + "/db"
+    let symlinkDBPath1 = tmp + "/db-link1"
+    let symlinkDBPath2 = tmp + "/db-link2"
+    try fileMgr.createDirectory(atPath: mainDBPath, withIntermediateDirectories: true, attributes: nil)
+    try fileMgr.createSymbolicLink(atPath: symlinkDBPath1, withDestinationPath: mainDBPath)
+    try fileMgr.createSymbolicLink(atPath: symlinkDBPath2, withDestinationPath: mainDBPath)
+
+    for _ in 0..<iterations {
+      DispatchQueue.concurrentPerform(iterations: 2) { idx in
+        let dbPath = idx == 0 ? symlinkDBPath1 : symlinkDBPath2
+        let idxDB = try! IndexStoreDB(storePath: indexStorePath, databasePath: dbPath, library: libIndexStore, waitUntilDoneInitializing: true)
+      }
+    }
+  }
 }

--- a/Tests/IndexStoreDBTests/IndexStoreDBTests.swift
+++ b/Tests/IndexStoreDBTests/IndexStoreDBTests.swift
@@ -15,6 +15,13 @@ import ISDBTibs
 import XCTest
 import Foundation
 
+let isTSanEnabled: Bool = {
+  if let value = ProcessInfo.processInfo.environment["INDEXSTOREDB_ENABLED_THREAD_SANITIZER"] {
+    return value == "1" || value == "YES"
+  }
+  return false
+}()
+
 func checkThrows(_ expected: IndexStoreDBError, file: StaticString = #file, line: UInt = #line, _ body: () throws -> ()) {
   do {
     try body()
@@ -73,6 +80,9 @@ final class IndexStoreDBTests: XCTestCase {
   }
 
   func testSymlinkedDBPaths() throws {
+    // FIXME: This test seems to trigger a false-positive in TSan.
+    try XCTSkipIf(isTSanEnabled, "skipping because TSan is enabled")
+
     let toolchain = TibsToolchain.testDefault
     let libIndexStore = try! IndexStoreLibrary(dylibPath: toolchain.libIndexStore.path)
 

--- a/Tests/IndexStoreDBTests/XCTestManifests.swift
+++ b/Tests/IndexStoreDBTests/XCTestManifests.swift
@@ -8,6 +8,7 @@ extension IndexStoreDBTests {
     static let __allTests__IndexStoreDBTests = [
         ("testCreateIndexStoreAndDBDirs", testCreateIndexStoreAndDBDirs),
         ("testErrors", testErrors),
+        ("testSymlinkedDBPaths", testSymlinkedDBPaths),
     ]
 }
 

--- a/Utilities/build-script-helper.py
+++ b/Utilities/build-script-helper.py
@@ -62,6 +62,8 @@ def handle_invocation(swift_exec, args):
   if args.sanitize and 'undefined' in args.sanitize:
     supp = os.path.join(args.package_path, 'Utilities', 'ubsan_supressions.supp')
     env['UBSAN_OPTIONS'] = 'halt_on_error=true,suppressions=%s' % supp
+  if args.sanitize and 'thread' in args.sanitize:
+    env['INDEXSTOREDB_ENABLED_THREAD_SANITIZER'] = '1'
 
   # Workaround for incremental build bug in swiftpm.
   print('Cleaning ' + args.build_path)

--- a/lib/Database/DatabaseImpl.h
+++ b/lib/Database/DatabaseImpl.h
@@ -44,12 +44,11 @@ class Database::Implementation {
 
   dispatch_group_t ReadTxnGroup;
   dispatch_queue_t TxnSyncQueue;
-  dispatch_queue_t DiscardedDBsCleanupQueue;
 
   bool IsReadOnly;
   std::string VersionedPath;
   std::string SavedPath;
-  std::string ProcessPath;
+  std::string UniquePath;
 
 public:
   static std::shared_ptr<Implementation> create(StringRef dbPath, bool readonly, Optional<size_t> initialDBSize, std::string &error);


### PR DESCRIPTION
This is intended to protect against a crash that can occur if trying to use the same lmdb database path from separate wrapper instances.

rdar://39235399