### PR TITLE
[5.3][Database] Make the database path unique to the specific lmdb wrapper instance

### DIFF
--- a/Tests/INPUTS/SingleUnit/main.c
+++ b/Tests/INPUTS/SingleUnit/main.c
@@ -1,0 +1,1 @@
+void test() {}

--- a/Tests/INPUTS/SingleUnit/project.json
+++ b/Tests/INPUTS/SingleUnit/project.json
@@ -1,0 +1,1 @@
+{"sources": ["main.c"]}

--- a/Tests/IndexStoreDBTests/IndexStoreDBTests.swift
+++ b/Tests/IndexStoreDBTests/IndexStoreDBTests.swift
@@ -72,7 +72,37 @@ final class IndexStoreDBTests: XCTestCase {
     }
   }
 
-  static var allTests = [
-    ("testErrors", testErrors),
-    ]
+  func testSymlinkedDBPaths() throws {
+    let toolchain = TibsToolchain.testDefault
+    let libIndexStore = try! IndexStoreLibrary(dylibPath: toolchain.libIndexStore.path)
+
+    // This tests against a crash that was manifesting when creating separate `IndexStoreDB` instances against 2 DB paths
+    // that resolve to the same underlying directory (e.g. they were symlinked).
+    // It runs a number of iterations though it was not guaranteed that the issue would hit within a specific number
+    // of iterations, only that at *some* point, if you let it run indefinitely, it could trigger.
+    let iterations = 100
+
+    let indexStorePath: String
+    do {
+      // Don't care about specific index data, just want an index store directory containing *something*.
+      guard let ws = try staticTibsTestWorkspace(name: "SingleUnit") else { return }
+      try ws.buildAndIndex()
+      indexStorePath =  ws.builder.indexstore.path
+    }
+
+    let fileMgr = FileManager.default
+    let mainDBPath = tmp + "/db"
+    let symlinkDBPath1 = tmp + "/db-link1"
+    let symlinkDBPath2 = tmp + "/db-link2"
+    try fileMgr.createDirectory(atPath: mainDBPath, withIntermediateDirectories: true, attributes: nil)
+    try fileMgr.createSymbolicLink(atPath: symlinkDBPath1, withDestinationPath: mainDBPath)
+    try fileMgr.createSymbolicLink(atPath: symlinkDBPath2, withDestinationPath: mainDBPath)
+
+    for _ in 0..<iterations {
+      DispatchQueue.concurrentPerform(iterations: 2) { idx in
+        let dbPath = idx == 0 ? symlinkDBPath1 : symlinkDBPath2
+        let idxDB = try! IndexStoreDB(storePath: indexStorePath, databasePath: dbPath, library: libIndexStore, waitUntilDoneInitializing: true)
+      }
+    }
+  }
 }

--- a/Tests/IndexStoreDBTests/XCTestManifests.swift
+++ b/Tests/IndexStoreDBTests/XCTestManifests.swift
@@ -8,6 +8,7 @@ extension IndexStoreDBTests {
     static let __allTests__IndexStoreDBTests = [
         ("testCreateIndexStoreAndDBDirs", testCreateIndexStoreAndDBDirs),
         ("testErrors", testErrors),
+        ("testSymlinkedDBPaths", testSymlinkedDBPaths),
     ]
 }
 

--- a/lib/Database/DatabaseImpl.h
+++ b/lib/Database/DatabaseImpl.h
@@ -44,12 +44,11 @@ class Database::Implementation {
 
   dispatch_group_t ReadTxnGroup;
   dispatch_queue_t TxnSyncQueue;
-  dispatch_queue_t DiscardedDBsCleanupQueue;
 
   bool IsReadOnly;
   std::string VersionedPath;
   std::string SavedPath;
-  std::string ProcessPath;
+  std::string UniquePath;
 
 public:
   static std::shared_ptr<Implementation> create(StringRef dbPath, bool readonly, Optional<size_t> initialDBSize, std::string &error);


### PR DESCRIPTION
This is intended to protect against a crash that can occur if trying to use the same lmdb database path from separate wrapper instances.

rdar://39235399

master: https://github.com/apple/indexstore-db/pull/107