### PR TITLE
Fix race in index delegate callback 

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:4.2
+// swift-tools-version:5.0
 
 import PackageDescription
 
@@ -70,7 +70,11 @@ let package = Package(
     .target(
       name: "IndexStoreDB_Database",
       dependencies: ["IndexStoreDB_Core"],
-      path: "lib/Database"),
+      path: "lib/Database",
+      cSettings: [
+        .define("MDB_USE_POSIX_MUTEX", to: "1"),
+        .define("MDB_USE_ROBUST", to: "0"),
+      ]),
 
     // Core index types.
     .target(


### PR DESCRIPTION
All calls to `processingCompleted` are called from the unit processing queue, but `processingAddedPending` can be called from other queues, including an arbitrary queue in the case of `addUnitOutFilePaths` and `removeUnitOutFilePaths`.

The result is that if there is a session being processed, we might increment and decrement `PendingActions` concurrently. We obsevered an assertion failure where `NumActions` was greater than `NumActions`, which was likely caused by this race.

rdar://68024910

---

Also, switch to posix mutex in lmdb. TSan does not support sysv semaphores, so switch to posix mutex. Also,
disable robust mutexes, since we do not support multi-process access to the database anyway.