### PR TITLE
build: disable POSIX mutexes on Windows

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.3
+// swift-tools-version:5.2
 
 import PackageDescription
 

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.0
+// swift-tools-version:5.3
 
 import PackageDescription
 
@@ -72,7 +72,9 @@ let package = Package(
       dependencies: ["IndexStoreDB_Core"],
       path: "lib/Database",
       cSettings: [
-        .define("MDB_USE_POSIX_MUTEX", to: "1"),
+        .define("MDB_USE_POSIX_MUTEX", to: "1",
+                // Windows does not use POSIX mutex
+                .when(platforms: [.linux, .macOS])),
         .define("MDB_USE_ROBUST", to: "0"),
       ]),
 


### PR DESCRIPTION
Conditionalize the define to use POSIX mutexes to macOS and Linux
targets.  This would be easier to define as non-POSIX, but the package
description does not have the negative check nor a POSIX check.

This requires bumping the tools version to 5.3 to gain access to
Windows.