### PR TITLE
build: bump C++ standard to 14

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -95,5 +95,5 @@ let package = Package(
       path: "lib/LLVMSupport"),
   ],
 
-  cxxLanguageStandard: .cxx11
+  cxxLanguageStandard: .cxx14
 )


### PR DESCRIPTION
The Windows C++ runtime requires C++14.  This is handled transparently
when using the `clang-cl` driver, however, when building with s-p-m, the
`clang` driver is used instead.  This requires explicitly bumping
everything to C++14.