### PR TITLE
[test] Add missing dependency on tibs executable

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -50,7 +50,7 @@ let package = Package(
     // Test support library, built on top of tibs.
     .target(
       name: "ISDBTestSupport",
-      dependencies: ["IndexStoreDB", "ISDBTibs"]),
+      dependencies: ["IndexStoreDB", "ISDBTibs", "tibs"]),
 
     // MARK: C++ interface
 


### PR DESCRIPTION
This is a run-time dependency inside the tests.  The missing dependency wasn't generally visible when testing from the command-line unless you tried to build+test specific targets.