### PR TITLE
[build-script-helper] make it run under Python 3

### DIFF
--- a/Utilities/build-script-helper.py
+++ b/Utilities/build-script-helper.py
@@ -17,7 +17,7 @@ def swiftpm(action, swift_exec, swiftpm_args, env=None):
 def swiftpm_bin_path(swift_exec, swiftpm_args, env=None):
   cmd = [swift_exec, 'build', '--show-bin-path'] + swiftpm_args
   print(' '.join(cmd))
-  return subprocess.check_output(cmd, env=env).strip()
+  return subprocess.check_output(cmd, env=env, universal_newlines=True).strip()
 
 def get_swiftpm_options(args):
   swiftpm_args = [


### PR DESCRIPTION
I've been running the entire build under Python 3 lately, but I'd get the usual error about mixing strings with bytes if this wasn't set. With this change, no problem building and running the tests.