### PR TITLE
IndexStoreDB: use `ucrt` instead of `MSVCRT`

### DIFF
--- a/Sources/IndexStoreDB/IndexStoreDB.swift
+++ b/Sources/IndexStoreDB/IndexStoreDB.swift
@@ -17,7 +17,7 @@ import CIndexStoreDB
 #if canImport(Glibc)
 import Glibc
 #elseif os(Windows)
-import MSVCRT
+import ucrt
 #else
 import Darwin.POSIX
 #endif


### PR DESCRIPTION
There is nothing that requires the use of `MSVCRT`.  Use the modern C
library on Windows, which also helps remove the `visualc` module in the
Swift standard library.