### PR TITLE
[IndexSystemDelegate] Introduce `initialPendingUnits()` callback

### DIFF
--- a/include/IndexStoreDB/Index/IndexSystemDelegate.h
+++ b/include/IndexStoreDB/Index/IndexSystemDelegate.h
@@ -69,6 +69,9 @@ class INDEXSTOREDB_EXPORT IndexSystemDelegate {
 public:
   virtual ~IndexSystemDelegate() {}
 
+  /// Called when the datastore gets initialized and receives the number of available units.
+  virtual void initialPendingUnits(unsigned numUnits) {}
+
   virtual void processingAddedPending(unsigned NumActions) {}
   virtual void processingCompleted(unsigned NumActions) {}
 

--- a/lib/Index/IndexDatastore.cpp
+++ b/lib/Index/IndexDatastore.cpp
@@ -1057,6 +1057,10 @@ bool IndexDatastoreImpl::init(IndexStoreRef idxStore,
       evts.push_back(UnitEventInfo{evt.getKind(), evt.getUnitName()});
     }
 
+    if (EventNote.isInitial()) {
+      Delegate->initialPendingUnits(evts.size());
+    }
+
     auto session = std::make_shared<UnitProcessingSession>(eventsDeque, WeakUnitRepo, Delegate);
     session->process(std::move(evts), shouldWait);
   };

--- a/lib/Index/IndexSystem.cpp
+++ b/lib/Index/IndexSystem.cpp
@@ -63,6 +63,13 @@ public:
   }
 
 private:
+  virtual void initialPendingUnits(unsigned numUnits) override {
+    Queue.dispatch([this, numUnits]{
+      for (auto &other : Others)
+        other->initialPendingUnits(numUnits);
+    });
+  }
+
   virtual void processingAddedPending(unsigned NumActions) override {
     Queue.dispatch([this, NumActions]{
       PendingActions += NumActions;


### PR DESCRIPTION
This is useful for letting the delegate know how many initial units will be processed after initializing the datastore.