### PR TITLE
The README file in this repo has a bad link - [404:NotFound] - "llvm-project"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # IndexStoreDB
 
-IndexStoreDB is a source code indexing library. It provides a composable and efficient query API for looking up source code symbols, symbol occurrences, and relations. IndexStoreDB uses the libIndexStore library, which lives in [llvm-project](https://github.com/apple/llvm-project/tree/apple/master/clang/tools/IndexStore), for reading raw index data. Raw index data can be produced by compilers such as Clang and Swift using the `-index-store-path` option. IndexStoreDB enables efficiently querying this data by maintaining acceleration tables in a key-value database built with [LMDB](http://www.lmdb.tech/).
+IndexStoreDB is a source code indexing library. It provides a composable and efficient query API for looking up source code symbols, symbol occurrences, and relations. IndexStoreDB uses the libIndexStore library, which lives in [llvm-project](https://github.com/apple/llvm-project/tree/apple/main/clang/tools/IndexStore), for reading raw index data. Raw index data can be produced by compilers such as Clang and Swift using the `-index-store-path` option. IndexStoreDB enables efficiently querying this data by maintaining acceleration tables in a key-value database built with [LMDB](http://www.lmdb.tech/).
 
 IndexStoreDB's data model is derived from libIndexStore. For more information about libIndexStore, and producing raw indexing data, see the [Indexing While Building](https://docs.google.com/document/d/1cH2sTpgSnJZCkZtJl1aY-rzy4uGPcrI-6RrUpdATO2Q/) whitepaper.
 


### PR DESCRIPTION
The markup version of the readme that is displayed for the main page in this repo contains the following bad link:


Status code [404:NotFound] - Link: https://github.com/apple/llvm-project/tree/apple/master/clang/tools/IndexStore

It should be: https://github.com/apple/llvm-project/tree/apple/main/clang/tools/IndexStore

**Extra**

This bad link was found by a tool I recently created as part of an new experimental hobby project: https://github.com/MrCull/GitHub-Repo-ReadMe-Dead-Link-Finder

Re-check this Repo using the tool’s website: http://githubreadmechecker.com/Home/Search?SingleRepoUri=https%3a%2f%2fgithub.com%2fapple%2findexstore-db

If this has been helpful, or if you have any feedback on the tool itself, then please feel free to share your thoughts by adding a comment here, or adding to a “Discussion” in the tool’s Repo.