### PR TITLE
Add  `symbols(inFilePath path: String)`

### DIFF
--- a/Sources/ISDBTestSupport/INPUTS/CProject/d.c
+++ b/Sources/ISDBTestSupport/INPUTS/CProject/d.c
@@ -1,0 +1,5 @@
+#include "d.h"
+
+void /*a_function:def*/a_function(void) {
+  // Intentionally void.
+}

--- a/Sources/ISDBTestSupport/INPUTS/CProject/d.h
+++ b/Sources/ISDBTestSupport/INPUTS/CProject/d.h
@@ -1,0 +1,1 @@
+void /*a_function:decl*/a_function(void);

--- a/Sources/ISDBTestSupport/INPUTS/CProject/e.c
+++ b/Sources/ISDBTestSupport/INPUTS/CProject/e.c
@@ -1,0 +1,6 @@
+#include "d.h"
+#include "e.h"
+
+void /*some_other_function:def*/some_other_function(void) {
+  // Intentionally void.
+}

--- a/Sources/ISDBTestSupport/INPUTS/CProject/e.h
+++ b/Sources/ISDBTestSupport/INPUTS/CProject/e.h
@@ -1,0 +1,3 @@
+void some_other_function(void);
+
+// Intentionally void.

--- a/Sources/ISDBTestSupport/INPUTS/CProject/project.json
+++ b/Sources/ISDBTestSupport/INPUTS/CProject/project.json
@@ -1,0 +1,5 @@
+{
+  "targets": [
+    { "name": "D", "sources": ["d.c", "e.c"] }
+  ]
+}

--- a/Sources/ISDBTestSupport/INPUTS/SwiftModules/c.swift
+++ b/Sources/ISDBTestSupport/INPUTS/SwiftModules/c.swift
@@ -1,6 +1,13 @@
 import A
 import B
-public func ccc() {
+public func /*ccc:def*/ccc() {
   /*aaa:call:c*/aaa()
   /*bbb:call*/bbb()
+}
+
+
+public class DDD {
+  public func /*DDD:testMethod:def*/testMethod() {
+
+  }
 }

--- a/Sources/ISDBTestSupport/INPUTS/SwiftModules/project.json
+++ b/Sources/ISDBTestSupport/INPUTS/SwiftModules/project.json
@@ -2,6 +2,6 @@
   "targets": [
     { "name": "A", "sources": ["a.swift"] },
     { "name": "B", "sources": ["b.swift"], "dependencies": ["A"] },
-    { "name": "C", "sources": ["c.swift"], "dependencies": ["B"] },
+    { "name": "C", "sources": ["c.swift"], "dependencies": ["B"]},
   ]
 }

--- a/Sources/IndexStoreDB/IndexStoreDB.swift
+++ b/Sources/IndexStoreDB/IndexStoreDB.swift
@@ -329,6 +329,22 @@ public final class IndexStoreDB {
     }
     return result
   }
+
+  public func symbols(inFilePath path: String) -> [Symbol] {
+    var result: [Symbol] = []
+    forEachSymbol(inFilePath: path) { sym in
+      result.append(sym)
+      return true
+    }
+    return result
+  }
+
+  @discardableResult
+  func forEachSymbol(inFilePath filePath: String, body: @escaping (Symbol) -> Bool) -> Bool {
+    return indexstoredb_index_symbols_contained_in_file_path(impl, filePath) { symbol in
+      return body(Symbol(symbol))
+    }
+  }
 }
 
 public protocol IndexStoreLibraryProvider {

--- a/include/CIndexStoreDB/CIndexStoreDB.h
+++ b/include/CIndexStoreDB/CIndexStoreDB.h
@@ -128,6 +128,9 @@ typedef void *indexstoredb_delegate_event_t;
 typedef _Nullable indexstoredb_indexstore_library_t(^indexstore_library_provider_t)(const char * _Nonnull);
 
 /// Returns true to continue.
+typedef bool(^indexstoredb_symbol_receiver_t)(_Nonnull indexstoredb_symbol_t);
+
+/// Returns true to continue.
 typedef bool(^indexstoredb_symbol_occurrence_receiver_t)(_Nonnull indexstoredb_symbol_occurrence_t);
 
 /// Returns true to continue.
@@ -220,6 +223,15 @@ indexstoredb_index_related_symbol_occurrences_by_usr(
     const char *_Nonnull usr,
     uint64_t roles,
     _Nonnull indexstoredb_symbol_occurrence_receiver_t);
+
+/// Iterates over all the symbols contained in \p path
+/// 
+/// The symbol passed to the receiver is only valid for the duration of the
+/// receiver call.
+INDEXSTOREDB_PUBLIC bool
+indexstoredb_index_symbols_contained_in_file_path(_Nonnull indexstoredb_index_t index,
+                                                  const char *_Nonnull path,
+                                                  _Nonnull indexstoredb_symbol_receiver_t);
 
 /// Returns the USR of the given symbol.
 ///

--- a/include/IndexStoreDB/Index/IndexSystem.h
+++ b/include/IndexStoreDB/Index/IndexSystem.h
@@ -25,9 +25,14 @@
 namespace IndexStoreDB {
   class CanonicalFilePathRef;
   class SymbolOccurrence;
+  class Symbol;
+
   enum class SymbolRole : uint64_t;
   enum class SymbolKind : uint8_t;
+
   typedef std::shared_ptr<SymbolOccurrence> SymbolOccurrenceRef;
+  typedef std::shared_ptr<Symbol> SymbolRef;
+
   typedef llvm::OptionSet<SymbolRole> SymbolRoleSet;
 
 namespace index {
@@ -89,6 +94,9 @@ public:
   //===--------------------------------------------------------------------===//
   // Queries
   //===--------------------------------------------------------------------===//
+
+  bool foreachSymbolInFilePath(StringRef FilePath,
+                               function_ref<bool(SymbolRef Symbol)> Receiver);
 
   bool foreachSymbolOccurrenceByUSR(StringRef USR, SymbolRoleSet RoleSet,
                         function_ref<bool(SymbolOccurrenceRef Occur)> Receiver);

--- a/include/IndexStoreDB/Index/SymbolIndex.h
+++ b/include/IndexStoreDB/Index/SymbolIndex.h
@@ -64,6 +64,9 @@ public:
   bool foreachRelatedSymbolOccurrenceByUSR(StringRef USR, SymbolRoleSet RoleSet,
                         function_ref<bool(SymbolOccurrenceRef Occur)> Receiver);
 
+  bool foreachSymbolInFilePath(CanonicalFilePathRef filePath,
+                               function_ref<bool(SymbolRef Occur)> Receiver);
+
   bool foreachCanonicalSymbolOccurrenceContainingPattern(StringRef Pattern,
                                                 bool AnchorStart,
                                                 bool AnchorEnd,

--- a/lib/CIndexStoreDB/CIndexStoreDB.cpp
+++ b/lib/CIndexStoreDB/CIndexStoreDB.cpp
@@ -189,6 +189,16 @@ indexstoredb_index_related_symbol_occurrences_by_usr(
     });
 }
 
+bool
+indexstoredb_index_symbols_contained_in_file_path(_Nonnull indexstoredb_index_t index,
+                                                   const char *_Nonnull path,
+                                                   _Nonnull indexstoredb_symbol_receiver_t receiver) {
+  auto obj = (Object<std::shared_ptr<IndexSystem>> *)index;
+  return obj->value->foreachSymbolInFilePath(path, [&](SymbolRef Symbol) -> bool {
+    return receiver((indexstoredb_symbol_receiver_t)Symbol.get());
+  });
+}
+
 const char *
 indexstoredb_symbol_usr(indexstoredb_symbol_t symbol) {
   auto value = (Symbol *)symbol;


### PR DESCRIPTION
## Overview
Add a new API which can be used to retrieve a list of symbol definitions or declarations from a file, like so:

```swift
func symbols(inFilePath path: String) -> [Symbol] { /* defined in PR */ }
```

## Usage
```swift
let symbols = Globals.index.symbols(inFilePath: path)
for symbol in symbols {
    print(symbol.name)
}
```

## Test Plan
I added integration tests with the guidance of @benlangmuir. These tests withstood mutation testing and caught meaningful errors during the development process.
