### PR TITLE
Bug Fix for copy_file_internal

### DIFF
--- a/lib/LLVMSupport/Support/Path.cpp
+++ b/lib/LLVMSupport/Support/Path.cpp
@@ -944,11 +944,13 @@ static std::error_code copy_file_internal(int ReadFD, int WriteFD) {
     BytesRead = read(ReadFD, Buf, BufSize);
     if (BytesRead <= 0)
       break;
+    char *BPtr = Buf;
     while (BytesRead) {
-      BytesWritten = write(WriteFD, Buf, BytesRead);
+      BytesWritten = write(WriteFD, BPtr, BytesRead);
       if (BytesWritten < 0)
         break;
       BytesRead -= BytesWritten;
+      BPtr += BytesWritten;
     }
     if (BytesWritten < 0)
       break;


### PR DESCRIPTION
Noticed this bug in the copy_file_internal code. As bytes are written you need to move through the buffer.