### PR TITLE
[5.5] Allow individual units that require a database file > 1 GB

### DIFF
--- a/lib/Index/IndexDatastore.cpp
+++ b/lib/Index/IndexDatastore.cpp
@@ -395,9 +395,10 @@ void StoreUnitRepo::onFilesChange(std::vector<UnitEventInfo> evts,
         break;
       } catch (db::MapFullError err) {
         // If we hit the map size limit try again but only for a limited number of times.
-        if (tries > 4) {
-          // If it still fails after doubling the map size 4 times then something is going
-          // wrong so give up.
+        if (tries > 6) {
+          // If it still fails after doubling the map size 6 times then something is going
+          // wrong so give up. The value 6 was obtained by taking the largest known single
+          // unit, which required 5 doublings, and adding 1 for margin of error.
           LOG_WARN("guardForMapFullError", "Still MDB_MAP_FULL error after increasing map size, tries: " << tries);
           throw;
         }


### PR DESCRIPTION
Cherry-pick https://github.com/apple/indexstore-db/pull/130 to release/5.5

---

We observed such a large unit in practice, so increase our retry limit
so that it can accomodate such a large unit even if it happens to be the
first one registered with the index and has to perform all the doublings
in a row. The goal of the retry limit is not to keep the DB small, but
to abort in the case of a bug causing unlimited growth.

rdar://77288893