### PR TITLE
[tibs] Workaround issue with new -emit-modules-separately behaviour

### DIFF
--- a/Sources/ISDBTibs/OutputFileMap.swift
+++ b/Sources/ISDBTibs/OutputFileMap.swift
@@ -18,11 +18,13 @@ public struct OutputFileMap {
 
   /// A single entry in the OutputFileMap.
   public struct Entry: Hashable, Codable {
+    public var object: String?
     public var swiftmodule: String?
     public var swiftdoc: String?
     public var dependencies: String?
 
-    public init(swiftmodule: String? = nil, swiftdoc: String? = nil, dependencies: String? = nil) {
+    public init(object: String? = nil, swiftmodule: String? = nil, swiftdoc: String? = nil, dependencies: String? = nil) {
+      self.object = object
       self.swiftmodule = swiftmodule
       self.swiftdoc = swiftdoc
       self.dependencies = dependencies

--- a/Sources/ISDBTibs/TibsResolvedTarget.swift
+++ b/Sources/ISDBTibs/TibsResolvedTarget.swift
@@ -34,7 +34,7 @@ public final class TibsResolvedTarget {
     public var sdk: String?
 
     public var indexOutputPaths: [String] {
-      return outputFileMap.values.compactMap{ $0.swiftmodule }
+      return outputFileMap.values.compactMap{ $0.object ?? $0.swiftmodule }
     }
 
     public init(

--- a/Tests/ISDBTibsTests/TibsCompilationDatabaseTests.swift
+++ b/Tests/ISDBTibsTests/TibsCompilationDatabaseTests.swift
@@ -45,7 +45,8 @@ final class TibsCompilationDatabaseTests: XCTestCase {
           "-emit-module", "-emit-module-path", "A.swiftmodule",
           "-emit-dependencies",
           "-pch-output-dir", "pch",
-          "-module-cache-path", "ModuleCache"
+          "-module-cache-path", "ModuleCache",
+          "-c",
         ] + sdkargs + [
           "-working-directory", "/build"
         ]),
@@ -61,7 +62,8 @@ final class TibsCompilationDatabaseTests: XCTestCase {
           "-emit-module", "-emit-module-path", "B.swiftmodule",
           "-emit-dependencies",
           "-pch-output-dir", "pch",
-          "-module-cache-path", "ModuleCache"
+          "-module-cache-path", "ModuleCache",
+          "-c",
         ] + sdkargs + [
           "-working-directory", "/build"
         ]),
@@ -76,7 +78,8 @@ final class TibsCompilationDatabaseTests: XCTestCase {
           "-emit-module", "-emit-module-path", "C.swiftmodule",
           "-emit-dependencies",
           "-pch-output-dir", "pch",
-          "-module-cache-path", "ModuleCache"
+          "-module-cache-path", "ModuleCache",
+          "-c",
         ] + sdkargs + [
           "-working-directory", "/build"
         ]),
@@ -104,6 +107,7 @@ final class TibsCompilationDatabaseTests: XCTestCase {
       "main.swiftmodule", "-emit-dependencies",
       "-pch-output-dir", "pch",
       "-module-cache-path", "ModuleCache",
+      "-c",
       "-emit-objc-header", "-emit-objc-header-path", "main-Swift.h",
       "-import-objc-header", "/src/bridging-header.h",
     ] + sdkargs + [


### PR DESCRIPTION
We are seeing sporadic test failures after the driver started using
-emit-modules-separately behaviour. For now, workaround by adding -c to
the command to force a per-file compilation. Long term we should figure
out a solution that lets us index and produce swiftmodules without
emitting the unnecessary .o files.

rdar://83215771