### PR TITLE
Database: repair the Windows build after #137

### DIFF
--- a/lib/Database/Database.cpp
+++ b/lib/Database/Database.cpp
@@ -24,6 +24,7 @@
 #include "llvm/Support/Path.h"
 #include "llvm/Support/raw_ostream.h"
 #if defined(_WIN32)
+#define NOMINMAX
 #include "Windows.h"
 #endif
 


### PR DESCRIPTION
Without `NOMINMAX`, `max` is defined as a macro which will then collide
with `std::max` from `<algorithm>`.  This repairs the Windows build.