### PR TITLE
[5.6][ISDBTibs/Makefile] Use `String(contentsOf:encoding:)` which gives the more efficient native String backing

### DIFF
--- a/Sources/ISDBTibs/Makefile.swift
+++ b/Sources/ISDBTibs/Makefile.swift
@@ -53,7 +53,7 @@ public struct Makefile {
   }
 
   public init?(path: URL) {
-    guard let contents = try? String(contentsOf: path) else {
+    guard let contents = try? String(contentsOf: path, encoding: .utf8) else {
       return nil
     }
     self.init(contents: contents)


### PR DESCRIPTION
Cherry-pick https://github.com/apple/indexstore-db/pull/141 to release/5.6

rdar://88172057