### PR TITLE
[5.7] Support for hermetic indexing + path remappings

### DIFF
--- a/Sources/ISDBTestSupport/INPUTS/HermeticMixedLang/a.swift
+++ b/Sources/ISDBTestSupport/INPUTS/HermeticMixedLang/a.swift
@@ -1,0 +1,9 @@
+#if os(macOS)
+func test(c: /*C:ref:swift*/C) {
+  c . /*C.method:call:swift*/method()
+}
+#endif
+
+func test() {
+  /*bridgingHeader:call*/bridgingHeader()
+}

--- a/Sources/ISDBTestSupport/INPUTS/HermeticMixedLang/bridging-header.h
+++ b/Sources/ISDBTestSupport/INPUTS/HermeticMixedLang/bridging-header.h
@@ -1,0 +1,3 @@
+#include "c.h"
+
+void /*bridgingHeader:decl*/bridgingHeader(void);

--- a/Sources/ISDBTestSupport/INPUTS/HermeticMixedLang/c.h
+++ b/Sources/ISDBTestSupport/INPUTS/HermeticMixedLang/c.h
@@ -1,0 +1,5 @@
+#ifdef __OBJC__
+@interface /*C:decl*/C
+-(void)/*C.method:decl*/method;
+@end
+#endif

--- a/Sources/ISDBTestSupport/INPUTS/HermeticMixedLang/c.m
+++ b/Sources/ISDBTestSupport/INPUTS/HermeticMixedLang/c.m
@@ -1,0 +1,7 @@
+#import "c.h"
+
+@implementation /*C:def*/C
+-(void)/*C.method:def*/method {
+
+}
+@end

--- a/Sources/ISDBTestSupport/INPUTS/HermeticMixedLang/project.json
+++ b/Sources/ISDBTestSupport/INPUTS/HermeticMixedLang/project.json
@@ -1,0 +1,9 @@
+{
+  "clang_flags": ["-Wno-objc-root-class", "-fdebug-prefix-map=$SRC_DIR=/SRC_ROOT", "-fdebug-prefix-map=$BUILD_DIR=/BUILD_ROOT"],
+  "swift_flags": ["-file-prefix-map", "$SRC_DIR=/SRC_ROOT", "-file-prefix-map", "$BUILD_DIR=/BUILD_ROOT"],
+  "sources": [
+    "a.swift",
+    "c.m",
+  ],
+  "bridging_header": "bridging-header.h"
+}

--- a/Sources/ISDBTestSupport/TibsTestWorkspace.swift
+++ b/Sources/ISDBTestSupport/TibsTestWorkspace.swift
@@ -171,6 +171,7 @@ public final class TibsTestWorkspace {
     waitUntilDoneInitializing: Bool = false,
     enableOutOfDateFileWatching: Bool = false,
     listenToUnitEvents: Bool = false,
+    prefixMappings: [PathMapping] = [],
     toolchain: TibsToolchain? = nil
   ) throws {
     let toolchain = toolchain ?? TibsToolchain.testDefault
@@ -184,7 +185,8 @@ public final class TibsTestWorkspace {
       useExplicitOutputUnits: useExplicitOutputUnits,
       waitUntilDoneInitializing: waitUntilDoneInitializing,
       enableOutOfDateFileWatching: enableOutOfDateFileWatching,
-      listenToUnitEvents: listenToUnitEvents)
+      listenToUnitEvents: listenToUnitEvents,
+      prefixMappings: prefixMappings)
   }
 
   deinit {

--- a/Sources/ISDBTibs/TibsBuilder.swift
+++ b/Sources/ISDBTibs/TibsBuilder.swift
@@ -47,8 +47,8 @@ public final class TibsBuilder {
         sourceRoot.appendingPathComponent($0, isDirectory: false)
       }
 
-      let swiftFlags = targetDesc.swiftFlags ?? []
-      let clangFlags = targetDesc.clangFlags ?? []
+      let swiftFlags = expandMagicVariables(targetDesc.swiftFlags ?? [], sourceRoot.path, buildRoot.path)
+      let clangFlags = expandMagicVariables(targetDesc.clangFlags ?? [], sourceRoot.path, buildRoot.path)
 
       let swiftSources = sources.filter { $0.pathExtension == "swift" }
       let clangSources = sources.filter { $0.pathExtension != "swift" }
@@ -166,6 +166,15 @@ extension TibsBuilder {
     } catch Process.TibsProcessError.nonZeroExit(let reason, let code, let stdout, let stderr) {
       throw Error.buildFailure(reason, exitCode: code, stdout: stdout, stderr: stderr)
     }
+  }
+}
+
+func expandMagicVariables(_ arguments: [String], _ sourceRoot: String, _ buildRoot: String) -> [String] {
+  return arguments.map { arg in
+    var expanded = arg
+    expanded = expanded.replacingOccurrences(of: "$SRC_DIR", with: sourceRoot)
+    expanded = expanded.replacingOccurrences(of: "$BUILD_DIR", with: buildRoot)
+    return expanded
   }
 }
 

--- a/Sources/IndexStoreDB/IndexStoreDB.swift
+++ b/Sources/IndexStoreDB/IndexStoreDB.swift
@@ -22,6 +22,19 @@ import ucrt
 import Darwin.POSIX
 #endif
 
+public struct PathMapping {
+  /// Path prefix to be replaced, typically the canonical or hermetic path.
+  let original: String
+
+  /// Replacement path prefix, typically the path on the local machine.
+  let replacement: String
+
+  public init(original: String, replacement: String) {
+    self.original = original
+    self.replacement = replacement
+  }
+}
+
 /// IndexStoreDB index.
 public final class IndexStoreDB {
 
@@ -43,6 +56,7 @@ public final class IndexStoreDB {
   ///   * listenToUnitEvents: Only `true` is supported outside unit tests. Setting to `false`
   ///     disables reading or updating from the index store unless `pollForUnitChangesAndWait()`
   ///     is called.
+  ///   * prefixMappings: Path mappings to use (if supported) to remap paths in the index data to paths on the local machine.
   public init(
     storePath: String,
     databasePath: String,
@@ -52,7 +66,8 @@ public final class IndexStoreDB {
     waitUntilDoneInitializing wait: Bool = false,
     readonly: Bool = false,
     enableOutOfDateFileWatching: Bool = false,
-    listenToUnitEvents: Bool = true
+    listenToUnitEvents: Bool = true,
+    prefixMappings: [PathMapping] = []
   ) throws {
     self.delegate = delegate
 
@@ -63,15 +78,26 @@ public final class IndexStoreDB {
     let delegateFunc = { [weak delegate] (event: indexstoredb_delegate_event_t) -> () in
       delegate?.handleEvent(event)
     }
+    let options = indexstoredb_creation_options_create()
+    defer { indexstoredb_creation_options_dispose(options) }
+    indexstoredb_creation_options_use_explicit_output_units(options, useExplicitOutputUnits)
+    indexstoredb_creation_options_wait(options, wait)
+    indexstoredb_creation_options_readonly(options, readonly)
+    indexstoredb_creation_options_enable_out_of_date_file_watching(options, enableOutOfDateFileWatching)
+    indexstoredb_creation_options_listen_to_unit_events(options, listenToUnitEvents)
+    for mapping in prefixMappings {
+      mapping.original.withCString { origCStr in
+        mapping.replacement.withCString { remappedCStr in
+          indexstoredb_creation_options_add_prefix_mapping(options, origCStr, remappedCStr)
+        }
+      }
+    }
 
     var error: indexstoredb_error_t? = nil
     guard let index = indexstoredb_index_create(
       storePath, databasePath,
       libProviderFunc, delegateFunc,
-      useExplicitOutputUnits,
-      wait, readonly,
-      enableOutOfDateFileWatching, listenToUnitEvents,
-      &error
+      options, &error
     ) else {
       defer { indexstoredb_error_dispose(error) }
       throw IndexStoreDBError.create(error?.description ?? "unknown")

--- a/Tests/IndexStoreDBTests/IndexTests.swift
+++ b/Tests/IndexStoreDBTests/IndexTests.swift
@@ -143,6 +143,90 @@ final class IndexTests: XCTestCase {
     ])
   }
 
+  func testHermeticMixedLang() throws {
+    guard let ws = try staticTibsTestWorkspace(name: "HermeticMixedLang") else { return }
+    // Provide the reverse mappings to the one in the project.json.
+    try ws.reinitIndexStore(waitUntilDoneInitializing: true, prefixMappings: [
+      PathMapping(original: "/SRC_ROOT", replacement: ws.sources.rootDirectory.path),
+      PathMapping(original: "/BUILD_ROOT", replacement: ws.builder.buildRoot.path)
+    ])
+    try ws.buildAndIndex()
+    let index = ws.index
+
+  #if os(macOS)
+    let cdecl = Symbol(usr: "c:objc(cs)C", name: "C", kind: .class)
+    let cdeclOccs = index.occurrences(ofUSR: cdecl.usr, roles: .all)
+    checkOccurrences(cdeclOccs, expected: [
+      cdecl.at(ws.testLoc("C:decl"), roles: [.declaration, .canonical]),
+      cdecl.at(ws.testLoc("C:def"), roles: .definition),
+      cdecl.at(ws.testLoc("C:ref:swift"), roles: .reference),
+    ])
+
+    let cmethod = Symbol(usr: "c:objc(cs)C(im)method", name: "method", kind: .instanceMethod)
+    let cmethodOccs = index.occurrences(ofUSR: cmethod.usr, roles: .all)
+    checkOccurrences(cmethodOccs, expected: [
+      cmethod.with(name: "method()").at(ws.testLoc("C.method:call:swift"), roles: [.call, .dynamic]),
+      cmethod.at(ws.testLoc("C.method:decl"), roles: .declaration),
+      cmethod.at(ws.testLoc("C.method:def"), roles: .definition),
+    ])
+  #endif
+
+    let bhdecl = Symbol(usr: "c:@F@bridgingHeader", name: "bridgingHeader", kind: .function)
+    let bridgingHeaderOccs = index.occurrences(ofUSR: bhdecl.usr, roles: .all)
+    checkOccurrences(bridgingHeaderOccs, expected: [
+      bhdecl.at(ws.testLoc("bridgingHeader:decl"), roles: .declaration),
+      bhdecl.with(name: "bridgingHeader()").at(ws.testLoc("bridgingHeader:call"), roles: .call),
+    ])
+  }
+
+  func testHermeticExplicitOutputUnits() throws {
+    guard let ws = try staticTibsTestWorkspace(name: "HermeticMixedLang", useExplicitOutputUnits: true) else { return }
+    // Provide the reverse mappings to the one in the project.json.
+    try ws.reinitIndexStore(useExplicitOutputUnits: true,
+                            prefixMappings: [
+      PathMapping(original: "/SRC_ROOT", replacement: ws.sources.rootDirectory.path),
+      PathMapping(original: "/BUILD_ROOT", replacement: ws.builder.buildRoot.path)
+    ])
+    try ws.buildAndIndex()
+    let index = ws.index
+
+  #if os(macOS)
+    let cdecl = Symbol(usr: "c:objc(cs)C", name: "C", kind: .class)
+    let getOccs = { index.occurrences(ofUSR: cdecl.usr, roles: .all) }
+
+    // Output units are not set yet.
+    XCTAssertEqual(0, getOccs().count)
+  #endif
+
+    // We must use the canonical output paths, not the local ones.
+    let indexOutputPaths = ws.builder.indexOutputPaths.map {
+      $0.path.replacingOccurrences(of: ws.builder.buildRoot.path, with: "/BUILD_ROOT")
+    }
+    index.addUnitOutFilePaths(indexOutputPaths, waitForProcessing: true)
+
+    // The bridging header is referenced as a PCH unit dependency, make sure we can see the data.
+    let bhdecl = Symbol(usr: "c:@F@bridgingHeader", name: "bridgingHeader", kind: .function)
+    let bridgingHeaderOccs = index.occurrences(ofUSR: bhdecl.usr, roles: .all)
+    checkOccurrences(bridgingHeaderOccs, expected: [
+      bhdecl.at(ws.testLoc("bridgingHeader:decl"), roles: .declaration),
+      bhdecl.with(name: "bridgingHeader()").at(ws.testLoc("bridgingHeader:call"), roles: .call),
+    ])
+  #if os(macOS)
+    checkOccurrences(getOccs(), expected: [
+      cdecl.at(ws.testLoc("C:decl"), roles: [.declaration, .canonical]),
+      cdecl.at(ws.testLoc("C:def"), roles: .definition),
+      cdecl.at(ws.testLoc("C:ref:swift"), roles: .reference),
+    ])
+
+    let outUnitASwift = try XCTUnwrap(indexOutputPaths.first{ $0.hasSuffix("-a.swift.o") })
+    index.removeUnitOutFilePaths([outUnitASwift], waitForProcessing: true)
+    checkOccurrences(getOccs(), expected: [
+      cdecl.at(ws.testLoc("C:decl"), roles: [.declaration, .canonical]),
+      cdecl.at(ws.testLoc("C:def"), roles: .definition),
+    ])
+  #endif
+  }
+
   func testSwiftModules() throws {
     guard let ws = try staticTibsTestWorkspace(name: "SwiftModules") else { return }
     try ws.buildAndIndex()

--- a/include/CIndexStoreDB/CIndexStoreDB.h
+++ b/include/CIndexStoreDB/CIndexStoreDB.h
@@ -161,6 +161,43 @@ typedef bool(^indexstoredb_file_includes_receiver)(const char *_Nonnull sourcePa
 /// Returns true to continue.
 typedef bool(^indexstoredb_unit_includes_receiver)(const char *_Nonnull sourcePath, const char *_Nonnull targetPath, size_t line);
 
+typedef void *indexstoredb_creation_options_t;
+
+INDEXSTOREDB_PUBLIC indexstoredb_creation_options_t _Nonnull
+indexstoredb_creation_options_create(void);
+
+INDEXSTOREDB_PUBLIC void
+indexstoredb_creation_options_dispose(indexstoredb_creation_options_t _Nonnull);
+
+/// Adds a remapping from \c path_prefix to \c remapped_path_prefix.
+///
+/// This should be used to convert hermetic or remote paths embedded in the index data to the
+/// equivalent paths on the local machine.
+INDEXSTOREDB_PUBLIC void
+indexstoredb_creation_options_add_prefix_mapping(indexstoredb_creation_options_t _Nonnull options,
+                                                 const char * _Nonnull pathPrefix,
+                                                 const char * _Nonnull remappedPathPrefix);
+
+INDEXSTOREDB_PUBLIC void
+indexstoredb_creation_options_listen_to_unit_events(indexstoredb_creation_options_t _Nonnull options,
+                                                        bool listenToUnitEvents);
+
+INDEXSTOREDB_PUBLIC void
+indexstoredb_creation_options_enable_out_of_date_file_watching(indexstoredb_creation_options_t _Nonnull options,
+                                                               bool enableOutOfDateFileWatching);
+
+INDEXSTOREDB_PUBLIC void
+indexstoredb_creation_options_readonly(indexstoredb_creation_options_t _Nonnull options,
+                                           bool readonly);
+
+INDEXSTOREDB_PUBLIC void
+indexstoredb_creation_options_wait(indexstoredb_creation_options_t _Nonnull options,
+                                       bool wait);
+
+INDEXSTOREDB_PUBLIC void
+indexstoredb_creation_options_use_explicit_output_units(indexstoredb_creation_options_t _Nonnull options,
+                                                            bool useExplicitOutputUnits);
+
 /// Creates an index for the given raw index data in \p storePath.
 ///
 /// The resulting index must be released using \c indexstoredb_release.
@@ -170,11 +207,7 @@ indexstoredb_index_create(const char * _Nonnull storePath,
                   const char * _Nonnull databasePath,
                   _Nonnull indexstore_library_provider_t libProvider,
                   _Nonnull indexstoredb_delegate_event_receiver_t delegate,
-                  bool useExplicitOutputUnits,
-                  bool wait,
-                  bool readonly,
-                  bool enableOutOfDateFileWatching,
-                  bool listenToUnitEvents,
+                  indexstoredb_creation_options_t _Nonnull options,
                   indexstoredb_error_t _Nullable * _Nullable);
 
 /// Add an additional delegate to the given index.

--- a/include/IndexStoreDB/Index/IndexSystem.h
+++ b/include/IndexStoreDB/Index/IndexSystem.h
@@ -15,6 +15,7 @@
 
 #include "IndexStoreDB/Support/LLVM.h"
 #include "IndexStoreDB/Support/Visibility.h"
+#include "indexstore/IndexStoreCXX.h"
 #include "llvm/ADT/OptionSet.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/Chrono.h"
@@ -43,6 +44,15 @@ namespace index {
   struct StoreUnitInfo;
   class IndexStoreLibraryProvider;
 
+struct CreationOptions {
+  indexstore::IndexStoreCreationOptions indexStoreOptions;
+  bool useExplicitOutputUnits = false;
+  bool wait = false;
+  bool readonly = false;
+  bool enableOutOfDateFileWatching = false;
+  bool listenToUnitEvents = true;
+};
+
 class INDEXSTOREDB_EXPORT IndexSystem {
 public:
   ~IndexSystem();
@@ -51,11 +61,7 @@ public:
                                              StringRef dbasePath,
                                              std::shared_ptr<IndexStoreLibraryProvider> storeLibProvider,
                                              std::shared_ptr<IndexSystemDelegate> Delegate,
-                                             bool useExplicitOutputUnits,
-                                             bool readonly,
-                                             bool enableOutOfDateFileWatching,
-                                             bool listenToUnitEvents,
-                                             bool waitUntilDoneInitializing,
+                                             const CreationOptions &options,
                                              Optional<size_t> initialDBSize,
                                              std::string &Error);
 

--- a/include/indexstore/indexstore_functions.h
+++ b/include/indexstore/indexstore_functions.h
@@ -25,7 +25,7 @@
  * INDEXSTORE_VERSION_MAJOR is intended for "major" source/ABI breaking changes.
  */
 #define INDEXSTORE_VERSION_MAJOR 0
-#define INDEXSTORE_VERSION_MINOR 11
+#define INDEXSTORE_VERSION_MINOR 13
 
 #define INDEXSTORE_VERSION_ENCODE(major, minor) ( \
       ((major) * 10000)                           \
@@ -79,6 +79,7 @@ typedef struct {
 } indexstore_string_ref_t;
 
 typedef void *indexstore_t;
+typedef void *indexstore_creation_options_t;
 
 typedef void *indexstore_unit_event_notification_t;
 typedef void *indexstore_unit_event_t;
@@ -235,8 +236,24 @@ typedef struct {
   unsigned
   (*format_version)(void);
 
+  indexstore_creation_options_t
+  (*creation_options_create)(void);
+
+  void
+  (*creation_options_dispose)(indexstore_creation_options_t);
+
+  void
+  (*creation_options_add_prefix_mapping)(indexstore_creation_options_t options,
+                                         const char *path_prefix,
+                                         const char *remapped_path_prefix);
+
   indexstore_t
   (*store_create)(const char *store_path, indexstore_error_t *error);
+
+  indexstore_t
+  (*store_create_with_options)(const char *store_path,
+                               indexstore_creation_options_t options,
+                               indexstore_error_t *error);
 
   void
   (*store_dispose)(indexstore_t);

--- a/lib/CIndexStoreDB/CIndexStoreDB.cpp
+++ b/lib/CIndexStoreDB/CIndexStoreDB.cpp
@@ -96,23 +96,75 @@ public:
 
 } // end anonymous namespace
 
+indexstoredb_creation_options_t
+indexstoredb_creation_options_create(void) {
+  return new CreationOptions();
+}
+
+void
+indexstoredb_creation_options_dispose(indexstoredb_creation_options_t c_options) {
+  auto *options = static_cast<CreationOptions *>(c_options);
+  delete options;
+}
+
+void
+indexstoredb_creation_options_add_prefix_mapping(indexstoredb_creation_options_t c_options,
+                                                 const char *path_prefix,
+                                                 const char *remapped_path_prefix) {
+  auto *options = static_cast<CreationOptions *>(c_options);
+  options->indexStoreOptions.addPrefixMapping(path_prefix, remapped_path_prefix);
+}
+
+void
+indexstoredb_creation_options_listen_to_unit_events(indexstoredb_creation_options_t c_options,
+                                                        bool listenToUnitEvents) {
+  auto *options = static_cast<CreationOptions *>(c_options);
+  options->listenToUnitEvents = listenToUnitEvents;
+}
+
+void
+indexstoredb_creation_options_enable_out_of_date_file_watching(indexstoredb_creation_options_t c_options,
+                                                               bool enableOutOfDateFileWatching) {
+  auto *options = static_cast<CreationOptions *>(c_options);
+  options->enableOutOfDateFileWatching = enableOutOfDateFileWatching;
+}
+
+void
+indexstoredb_creation_options_readonly(indexstoredb_creation_options_t c_options,
+                                           bool readonly) {
+  auto *options = static_cast<CreationOptions *>(c_options);
+  options->readonly = readonly;
+}
+
+void
+indexstoredb_creation_options_wait(indexstoredb_creation_options_t c_options,
+                                       bool wait) {
+  auto *options = static_cast<CreationOptions *>(c_options);
+  options->wait = wait;
+}
+
+void
+indexstoredb_creation_options_use_explicit_output_units(indexstoredb_creation_options_t c_options,
+                                                            bool useExplicitOutputUnits) {
+  auto *options = static_cast<CreationOptions *>(c_options);
+  options->useExplicitOutputUnits = useExplicitOutputUnits;
+}
+
 indexstoredb_index_t
 indexstoredb_index_create(const char *storePath, const char *databasePath,
                           indexstore_library_provider_t libProvider,
                           indexstoredb_delegate_event_receiver_t delegateCallback,
-                          bool useExplicitOutputUnits, bool wait, bool readonly,
-                          bool enableOutOfDateFileWatching, bool listenToUnitEvents,
+                          indexstoredb_creation_options_t cOptions,
                           indexstoredb_error_t *error) {
 
   auto delegate = std::make_shared<BlockIndexSystemDelegate>(delegateCallback);
   auto libProviderObj = std::make_shared<BlockIndexStoreLibraryProvider>(libProvider);
+  auto options = static_cast<CreationOptions *>(cOptions);
 
   std::string errMsg;
   if (auto index =
           IndexSystem::create(storePath, databasePath, libProviderObj, delegate,
-                              useExplicitOutputUnits, readonly,
-                              enableOutOfDateFileWatching, listenToUnitEvents, wait,
-                              llvm::None, errMsg)) {
+                              *options, llvm::None, errMsg)) {
 
     return make_object(index);
 

--- a/lib/Index/IndexDatastore.h
+++ b/lib/Index/IndexDatastore.h
@@ -30,6 +30,7 @@ namespace IndexStoreDB {
 namespace index {
   class IndexSystemDelegate;
   class SymbolIndex;
+  struct CreationOptions;
   typedef std::shared_ptr<SymbolIndex> SymbolIndexRef;
 
 class IndexDatastore {
@@ -40,11 +41,7 @@ public:
                                                 SymbolIndexRef SymIndex,
                                                 std::shared_ptr<IndexSystemDelegate> Delegate,
                                                 std::shared_ptr<CanonicalPathCache> CanonPathCache,
-                                                bool useExplicitOutputUnits,
-                                                bool readonly,
-                                                bool enableOutOfDateFileWatching,
-                                                bool listenToUnitEvents,
-                                                bool waitUntilDoneInitializing,
+                                                const CreationOptions &Options,
                                                 std::string &Error);
 
   bool isUnitOutOfDate(StringRef unitOutputPath, ArrayRef<StringRef> dirtyFiles);

--- a/lib/Index/indexstore_functions.def
+++ b/lib/Index/indexstore_functions.def
@@ -2,10 +2,14 @@
 // Format is Name/required. If 'required' is true then loading will fail if the symbol is missing,
 // otherwise loading will continue and the function pointer will be null.
 
+INDEXSTORE_FUNCTION(creation_options_add_prefix_mapping, false)
+INDEXSTORE_FUNCTION(creation_options_create, false)
+INDEXSTORE_FUNCTION(creation_options_dispose, false)
 INDEXSTORE_FUNCTION(error_get_description, true)
 INDEXSTORE_FUNCTION(error_dispose, true)
 INDEXSTORE_FUNCTION(format_version, true)
 INDEXSTORE_FUNCTION(store_create, true)
+INDEXSTORE_FUNCTION(store_create_with_options, false)
 INDEXSTORE_FUNCTION(store_dispose, true)
 #if INDEXSTORE_HAS_BLOCKS
 INDEXSTORE_FUNCTION(store_units_apply, true)


### PR DESCRIPTION
**Explanation**: https://github.com/apple/llvm-project/pull/4207 adds path remappings
to the index store to allow using hermetic index data but remapping
for local use without the need of any external tools like index-import.

This adds a new prefixMappings parameter to IndexStoreDB.init to allow giving the
prefix mapping to remap from hermetic/canonical --> local paths. If prefix
mappings are given while the new IndexStore API is unavailable,
indexstoredb creation will fail noting that the new API is only
available in newer versions of libIndexStore.

In addition, I've added a new `indexstoredb_creation_options_*` API to
allow configuring options when creating indexstoredb from Swift.

To support testing the remappings, TibsBuilder now supports
replacing arguments containing `$SRC_DIR` and `$BUILD_DIR` with
the respective directories.

(cherry picked from commit aff5369629596f5d1ae00676d775580a56343826)

**Scope**: Internal changes to IndexStoreDB making use of a newly added IndexStore API in the 5.7 release. IndexStoreDB constructor has changed but the new arg has a default value.

**Risk**: Low due to the test coverage below, main risk would be the new path remapping functionality.

**Testing**: Tests have been added for the remappings and pre-existing tests still pass.





