### PR TITLE
Add missing <ratio> header in "llvm/Support/Chrono.h"

### DIFF
--- a/include/llvm/Support/Chrono.h
+++ b/include/llvm/Support/Chrono.h
@@ -14,6 +14,7 @@
 
 #include <chrono>
 #include <ctime>
+#include <ratio>
 
 namespace llvm {
 


### PR DESCRIPTION
`Chrono.h` uses `ratio`, but doesn't include its corresponding header.
This is fine on main and on the regular SPM build because `chrono`
includes `ratio` in one of its private headers and main's `chrono` just
exports all the headers. But on rebranch the private headers are now ...
private and thus `ratio` is no longer visible.

Include it directly in `Chrono.h` to unblock rebranch for now.