### PR TITLE
ISDBTibs: honor `SDKROOT` as default SDK

### DIFF
--- a/Sources/ISDBTibs/TibsBuilder.swift
+++ b/Sources/ISDBTibs/TibsBuilder.swift
@@ -406,10 +406,12 @@ extension TibsBuilder {
 
   /// The default sdk path to use on Darwin (on other platforms, returns nil).
   public static var defaultSDKPath: String? = {
-    #if !os(macOS)
-    return nil
-    #else
+    #if os(macOS)
     return xcrunSDKPath()
+    #elseif os(Windows)
+    return ProcessInfo.processInfo.environment["SDKROOT"]
+    #else
+    return nil
     #endif
   }()
 }

--- a/Sources/ISDBTibs/TibsBuilder.swift
+++ b/Sources/ISDBTibs/TibsBuilder.swift
@@ -404,14 +404,12 @@ extension TibsBuilder {
 
 extension TibsBuilder {
 
-  /// The default sdk path to use on Darwin (on other platforms, returns nil).
+  /// The default sdk path to use.
   public static var defaultSDKPath: String? = {
     #if os(macOS)
     return xcrunSDKPath()
-    #elseif os(Windows)
-    return ProcessInfo.processInfo.environment["SDKROOT"]
     #else
-    return nil
+    return ProcessInfo.processInfo.environment["SDKROOT"]
     #endif
   }()
 }


### PR DESCRIPTION
Windows requires a SDK to be provided.  The default SDK path is the
location specified by `SDKROOT` in the environment.  Use this value for
the default value.