### PR TITLE
Tentative fix for MDB_PAGE_FULL errors

### DIFF
--- a/lib/Database/lmdb/mdb.c
+++ b/lib/Database/lmdb/mdb.c
@@ -9790,7 +9790,12 @@ mdb_page_split(MDB_cursor *mc, MDB_val *newkey, MDB_val *newdata, pgno_t newpgno
 			 * the split so the new page is emptier than the old page.
 			 * This yields better packing during sequential inserts.
 			 */
-			if (nkeys < 32 || nsize > pmax/16 || newindx >= nkeys) {
+// INDEXSTOREDB START
+// Changed in IndexStoreDB's copy of LMDB only. Should be removed once
+// ITS#9806 is fixed upstream. This changes the `nkeys < 32` check, which
+// seem to work well for larger than 4kb page sizes.
+			if (nkeys < env->me_psize/128 || nsize > pmax/16 || newindx >= nkeys) {
+// INDEXSTOREDB END
 				/* Find split point */
 				psize = 0;
 				if (newindx <= split_indx || newindx >= nkeys) {


### PR DESCRIPTION
https://bugs.openldap.org/show_bug.cgi?id=9806 notes MDB_PAGE_FULL can occur for widely varying record sizes (which we definitely have). The size chosen for `nkeys` was for 4KB pages, but M1s (and up) have 16KB pages. For now set this based on the page size of the system, at least until there's an actual fix in LMDB itself.

Resolves rdar://100363010.