### PR TITLE
Allow relative file paths during canonicalization

### DIFF
--- a/Sources/ISDBTestSupport/INPUTS/HermeticMixedLangRelativePaths/a.swift
+++ b/Sources/ISDBTestSupport/INPUTS/HermeticMixedLangRelativePaths/a.swift
@@ -1,0 +1,9 @@
+#if os(macOS)
+func test(c: /*C:ref:swift*/C) {
+  c . /*C.method:call:swift*/method()
+}
+#endif
+
+func test() {
+  /*bridgingHeader:call*/bridgingHeader()
+}

--- a/Sources/ISDBTestSupport/INPUTS/HermeticMixedLangRelativePaths/bridging-header.h
+++ b/Sources/ISDBTestSupport/INPUTS/HermeticMixedLangRelativePaths/bridging-header.h
@@ -1,0 +1,3 @@
+#include "c.h"
+
+void /*bridgingHeader:decl*/bridgingHeader(void);

--- a/Sources/ISDBTestSupport/INPUTS/HermeticMixedLangRelativePaths/c.h
+++ b/Sources/ISDBTestSupport/INPUTS/HermeticMixedLangRelativePaths/c.h
@@ -1,0 +1,5 @@
+#ifdef __OBJC__
+@interface /*C:decl*/C
+-(void)/*C.method:decl*/method;
+@end
+#endif

--- a/Sources/ISDBTestSupport/INPUTS/HermeticMixedLangRelativePaths/c.m
+++ b/Sources/ISDBTestSupport/INPUTS/HermeticMixedLangRelativePaths/c.m
@@ -1,0 +1,7 @@
+#import "c.h"
+
+@implementation /*C:def*/C
+-(void)/*C.method:def*/method {
+
+}
+@end

--- a/Sources/ISDBTestSupport/INPUTS/HermeticMixedLangRelativePaths/project.json
+++ b/Sources/ISDBTestSupport/INPUTS/HermeticMixedLangRelativePaths/project.json
@@ -1,0 +1,9 @@
+{
+  "clang_flags": ["-Wno-objc-root-class", "-fdebug-prefix-map=$SRC_DIR=.", "-fdebug-prefix-map=$BUILD_DIR=."],
+  "swift_flags": ["-file-prefix-map", "$SRC_DIR=.", "-file-prefix-map", "$BUILD_DIR=."],
+  "sources": [
+    "a.swift",
+    "c.m",
+  ],
+  "bridging_header": "bridging-header.h"
+}

--- a/include/IndexStoreDB/Database/ImportTransaction.h
+++ b/include/IndexStoreDB/Database/ImportTransaction.h
@@ -39,6 +39,7 @@ public:
                        StringRef USR, StringRef symbolName, SymbolInfo symInfo,
                        SymbolRoleSet roles, SymbolRoleSet relatedRoles);
   IDCode addFilePath(CanonicalFilePathRef filePath);
+  IDCode addUnitFileIdentifier(StringRef unitFile);
 
   void removeUnitData(IDCode unitCode);
   void removeUnitData(StringRef unitName);
@@ -55,7 +56,7 @@ class INDEXSTOREDB_EXPORT UnitDataImport {
   ImportTransaction &Import;
   std::string UnitName;
   CanonicalFilePath MainFile;
-  CanonicalFilePath OutFile;
+  StringRef OutFile;
   CanonicalFilePath Sysroot;
   llvm::sys::TimePoint<> ModTime;
   Optional<bool> IsSystem;
@@ -100,7 +101,7 @@ public:
   }
 
   void setMainFile(CanonicalFilePathRef mainFile);
-  void setOutFile(CanonicalFilePathRef outFile);
+  void setOutFile(StringRef outFile);
   void setSysroot(CanonicalFilePathRef sysroot);
   void setIsSystemUnit(bool isSystem);
   void setSymbolProviderKind(SymbolProviderKind K);

--- a/include/IndexStoreDB/Database/ReadTransaction.h
+++ b/include/IndexStoreDB/Database/ReadTransaction.h
@@ -81,6 +81,9 @@ public:
   bool getFullFilePathFromCode(IDCode filePathCode, raw_ostream &OS);
   CanonicalFilePath getFullFilePathFromCode(IDCode filePathCode);
   CanonicalFilePathRef getDirectoryFromCode(IDCode dirCode);
+  /// Returns empty path if it was not found. This should only be used for the unit path since it is not treated as
+  /// a canonicalized path.
+  StringRef getUnitFileIdentifierFromCode(IDCode fileCode);
 
   bool foreachDirPath(llvm::function_ref<bool(CanonicalFilePathRef dirPath)> receiver);
 
@@ -89,6 +92,7 @@ public:
                                     llvm::function_ref<bool(IDCode pathCode, CanonicalFilePathRef filePath)> receiver);
 
   IDCode getFilePathCode(CanonicalFilePathRef filePath);
+  IDCode getUnitFileIdentifierCode(StringRef filePath);
 
   /// UnitInfo.UnitName will be empty if \c unit was not found. UnitInfo.UnitCode is always filled out.
   UnitInfo getUnitInfo(IDCode unitCode);

--- a/include/IndexStoreDB/Index/StoreUnitInfo.h
+++ b/include/IndexStoreDB/Index/StoreUnitInfo.h
@@ -23,17 +23,17 @@ namespace index {
 struct StoreUnitInfo {
   std::string UnitName;
   CanonicalFilePath MainFilePath;
-  CanonicalFilePath OutFilePath;
+  StringRef OutFileIdentifier;
   bool HasTestSymbols = false;
   llvm::sys::TimePoint<> ModTime;
 
   StoreUnitInfo() = default;
   StoreUnitInfo(std::string unitName, CanonicalFilePath mainFilePath,
-                CanonicalFilePath outFilePath, bool hasTestSymbols,
+                StringRef outFileIdentifier, bool hasTestSymbols,
                 llvm::sys::TimePoint<> modTime)
       : UnitName(unitName),
         MainFilePath(mainFilePath),
-        OutFilePath(outFilePath),
+        OutFileIdentifier(outFileIdentifier),
         HasTestSymbols(hasTestSymbols),
         ModTime(modTime) {}
 };

--- a/lib/Database/ImportTransaction.cpp
+++ b/lib/Database/ImportTransaction.cpp
@@ -101,11 +101,14 @@ IDCode ImportTransaction::Implementation::addSymbolInfo(IDCode provider, StringR
 }
 
 IDCode ImportTransaction::Implementation::addFilePath(CanonicalFilePathRef canonFilePath) {
+  return addFilePath(canonFilePath.getPath());
+}
+
+IDCode ImportTransaction::Implementation::addFilePath(StringRef filePath) {
   auto &db = DBase->impl();
   auto &dbiDirNames = db.getDBIDirNameByCode();
   auto &dbiFilenames = db.getDBIFilenameByCode();
 
-  StringRef filePath = canonFilePath.getPath();
   IDCode filePathCode = makeIDCodeFromString(filePath);
   IDCode dirCode;
   StringRef dirName = llvm::sys::path::parent_path(filePath);
@@ -132,6 +135,11 @@ IDCode ImportTransaction::Implementation::addFilePath(CanonicalFilePathRef canon
   }
 
   return filePathCode;
+}
+
+
+IDCode ImportTransaction::Implementation::addUnitFileIdentifier(StringRef unitFile) {
+  return addFilePath(unitFile);
 }
 
 IDCode ImportTransaction::Implementation::addDirectory(CanonicalFilePathRef directory) {
@@ -378,6 +386,10 @@ IDCode ImportTransaction::addFilePath(CanonicalFilePathRef filePath) {
   return Impl->addFilePath(filePath);
 }
 
+IDCode ImportTransaction::addUnitFileIdentifier(StringRef unitFile) {
+  return Impl->addUnitFileIdentifier(unitFile);
+}
+
 void ImportTransaction::removeUnitData(IDCode unitCode) {
   return Impl->removeUnitData(unitCode);
 }
@@ -433,7 +445,7 @@ void UnitDataImport::setMainFile(CanonicalFilePathRef mainFile) {
   MainFile = mainFile;
 }
 
-void UnitDataImport::setOutFile(CanonicalFilePathRef outFile) {
+void UnitDataImport::setOutFile(StringRef outFile) {
   assert(!IsUpToDate);
   OutFile = outFile;
 }
@@ -532,9 +544,9 @@ void UnitDataImport::commit() {
   }
   IDCode outFileCode;
   if (!OutFile.empty()) {
-    outFileCode = makeIDCodeFromString(OutFile.getPath());
+    outFileCode = makeIDCodeFromString(OutFile);
     if (outFileCode != PrevOutFileCode)
-      import.addFilePath(OutFile);
+      import.addUnitFileIdentifier(OutFile);
   }
   bool hasSysroot = false;
   IDCode sysrootCode;

--- a/lib/Database/ImportTransactionImpl.h
+++ b/lib/Database/ImportTransactionImpl.h
@@ -35,8 +35,9 @@ public:
   /// \returns a IDCode of the USR.
   IDCode addSymbolInfo(IDCode provider, StringRef USR, StringRef symbolName, SymbolInfo symInfo,
                        SymbolRoleSet roles, SymbolRoleSet relatedRoles);
-  IDCode addFilePath(CanonicalFilePathRef filePath);
+  IDCode addFilePath(CanonicalFilePathRef canonFilePath);
   IDCode addDirectory(CanonicalFilePathRef directory);
+  IDCode addUnitFileIdentifier(StringRef unitFile);
   IDCode addTargetName(StringRef target);
   IDCode addModuleName(StringRef moduleName);
   /// If file is already associated, its timestamp is updated if \c modTime is more recent.
@@ -59,6 +60,9 @@ public:
   void removeUnitData(StringRef unitName);
 
   void commit();
+
+private:
+  IDCode addFilePath(StringRef filePath);
 };
 
 } // namespace db

--- a/lib/Database/ReadTransaction.cpp
+++ b/lib/Database/ReadTransaction.cpp
@@ -409,6 +409,15 @@ CanonicalFilePath ReadTransaction::Implementation::getFullFilePathFromCode(IDCod
   return CanonicalFilePathRef::getAsCanonicalPath(path);
 }
 
+StringRef ReadTransaction::Implementation::getUnitFileIdentifierFromCode(IDCode filePathCode) {
+  SmallString<128> path;
+  {
+    llvm::raw_svector_ostream OS(path);
+    getFullFilePathFromCode(filePathCode, OS);
+  }
+  return path;
+}
+
 CanonicalFilePathRef ReadTransaction::Implementation::getDirectoryFromCode(IDCode dirCode) {
   lmdb::val key{&dirCode, sizeof(dirCode)};
   lmdb::val value{};
@@ -484,6 +493,10 @@ bool ReadTransaction::Implementation::findFilePathsWithParentPaths(ArrayRef<Cano
 
 IDCode ReadTransaction::Implementation::getFilePathCode(CanonicalFilePathRef filePath) {
   return makeIDCodeFromString(filePath.getPath());
+}
+
+IDCode ReadTransaction::Implementation::getUnitPathCode(StringRef filePath) {
+  return makeIDCodeFromString(filePath);
 }
 
 bool ReadTransaction::Implementation::getFilePathFromValue(lmdb::val &filePathValue, raw_ostream &OS) {
@@ -721,6 +734,10 @@ CanonicalFilePath ReadTransaction::getFullFilePathFromCode(IDCode filePathCode) 
   return Impl->getFullFilePathFromCode(filePathCode);
 }
 
+StringRef ReadTransaction::getUnitFileIdentifierFromCode(IDCode filePathCode) {
+  return Impl->getUnitFileIdentifierFromCode(filePathCode);
+}
+
 CanonicalFilePathRef ReadTransaction::getDirectoryFromCode(IDCode dirCode) {
   return Impl->getDirectoryFromCode(dirCode);
 }
@@ -736,6 +753,10 @@ bool ReadTransaction::findFilePathsWithParentPaths(ArrayRef<CanonicalFilePathRef
 
 IDCode ReadTransaction::getFilePathCode(CanonicalFilePathRef filePath) {
   return Impl->getFilePathCode(filePath);
+}
+
+IDCode ReadTransaction::getUnitFileIdentifierCode(StringRef filePath) {
+  return Impl->getUnitPathCode(filePath);
 }
 
 UnitInfo ReadTransaction::getUnitInfo(IDCode unitCode) {

--- a/lib/Database/ReadTransactionImpl.h
+++ b/lib/Database/ReadTransactionImpl.h
@@ -83,10 +83,14 @@ public:
   /// Returns empty path if it was not found.
   CanonicalFilePath getFullFilePathFromCode(IDCode filePathCode);
   CanonicalFilePathRef getDirectoryFromCode(IDCode dirCode);
+  /// Returns empty path if it was not found. This should only be used for the unit path since it is not treated as
+  ///  a canonicalized path.
+  StringRef getUnitFileIdentifierFromCode(IDCode fileCode);
   bool foreachDirPath(llvm::function_ref<bool(CanonicalFilePathRef dirPath)> receiver);
   bool findFilePathsWithParentPaths(ArrayRef<CanonicalFilePathRef> parentPaths,
                                     llvm::function_ref<bool(IDCode pathCode, CanonicalFilePathRef filePath)> receiver);
   IDCode getFilePathCode(CanonicalFilePathRef filePath);
+  IDCode getUnitPathCode(StringRef filePath);
 
   /// UnitInfo.UnitName will be empty if \c unit was not found. UnitInfo.UnitCode is always filled out.
   UnitInfo getUnitInfo(IDCode unitCode);

--- a/lib/Index/FilePathIndex.cpp
+++ b/lib/Index/FilePathIndex.cpp
@@ -165,7 +165,7 @@ bool FileIndexImpl::foreachMainUnitContainingFile(CanonicalFilePathRef filePath,
       currUnit.UnitName = unitInfo.UnitName;
       currUnit.ModTime = unitInfo.ModTime;
       currUnit.MainFilePath = reader.getFullFilePathFromCode(unitInfo.MainFileCode);
-      currUnit.OutFilePath = reader.getFullFilePathFromCode(unitInfo.OutFileCode);
+      currUnit.OutFileIdentifier = reader.getUnitFileIdentifierFromCode(unitInfo.OutFileCode);
       return true;
     });
   }

--- a/lib/Index/FileVisibilityChecker.cpp
+++ b/lib/Index/FileVisibilityChecker.cpp
@@ -66,10 +66,7 @@ void FileVisibilityChecker::addUnitOutFilePaths(ArrayRef<StringRef> filePaths) {
 
   ReadTransaction reader(DBase);
   for (StringRef filePath : filePaths) {
-    CanonicalFilePath canonPath = CanonPathCache->getCanonicalPath(filePath);
-    if (canonPath.empty())
-      continue;
-    IDCode pathCode = reader.getFilePathCode(canonPath);
+    IDCode pathCode = reader.getUnitFileIdentifierCode(filePath);
     OutUnitFiles.insert(pathCode);
   }
   UnitVisibilityCache.clear();
@@ -80,10 +77,7 @@ void FileVisibilityChecker::removeUnitOutFilePaths(ArrayRef<StringRef> filePaths
 
   ReadTransaction reader(DBase);
   for (StringRef filePath : filePaths) {
-    CanonicalFilePath canonPath = CanonPathCache->getCanonicalPath(filePath);
-    if (canonPath.empty())
-      continue;
-    IDCode pathCode = reader.getFilePathCode(canonPath);
+    IDCode pathCode = reader.getUnitFileIdentifierCode(filePath);
     OutUnitFiles.erase(pathCode);
   }
   UnitVisibilityCache.clear();


### PR DESCRIPTION
Additionally, don't apply the working dir to unit paths, instead we should treat them as verbatim identifiers for the units.

This improves support for build systems such as Bazel where the build/execution root is remapped to ., meaning all paths including unit paths become relative. Previously, this wasn't supported because the unit name internally would be remapped to the absolute path when an index prefix mapping is used, instead of preserving the canonical unit path.

Note that the latest version of libIndexStore already makes paths absolute before writing them, so the only current way to get relative file paths in the index data is with index path mappings.

cc @bnbarham 