### PR TITLE
Fix dangling references to the stack

### DIFF
--- a/include/IndexStoreDB/Database/ImportTransaction.h
+++ b/include/IndexStoreDB/Database/ImportTransaction.h
@@ -56,7 +56,7 @@ class INDEXSTOREDB_EXPORT UnitDataImport {
   ImportTransaction &Import;
   std::string UnitName;
   CanonicalFilePath MainFile;
-  StringRef OutFile;
+  std::string OutFileIdentifier;
   CanonicalFilePath Sysroot;
   llvm::sys::TimePoint<> ModTime;
   Optional<bool> IsSystem;
@@ -101,7 +101,7 @@ public:
   }
 
   void setMainFile(CanonicalFilePathRef mainFile);
-  void setOutFile(StringRef outFile);
+  void setOutFileIdentifier(StringRef outFileIdentifier);
   void setSysroot(CanonicalFilePathRef sysroot);
   void setIsSystemUnit(bool isSystem);
   void setSymbolProviderKind(SymbolProviderKind K);

--- a/include/IndexStoreDB/Database/ReadTransaction.h
+++ b/include/IndexStoreDB/Database/ReadTransaction.h
@@ -83,7 +83,7 @@ public:
   CanonicalFilePathRef getDirectoryFromCode(IDCode dirCode);
   /// Returns empty path if it was not found. This should only be used for the unit path since it is not treated as
   /// a canonicalized path.
-  StringRef getUnitFileIdentifierFromCode(IDCode fileCode);
+  std::string getUnitFileIdentifierFromCode(IDCode fileCode);
 
   bool foreachDirPath(llvm::function_ref<bool(CanonicalFilePathRef dirPath)> receiver);
 

--- a/include/IndexStoreDB/Index/StoreUnitInfo.h
+++ b/include/IndexStoreDB/Index/StoreUnitInfo.h
@@ -23,7 +23,7 @@ namespace index {
 struct StoreUnitInfo {
   std::string UnitName;
   CanonicalFilePath MainFilePath;
-  StringRef OutFileIdentifier;
+  std::string OutFileIdentifier;
   bool HasTestSymbols = false;
   llvm::sys::TimePoint<> ModTime;
 

--- a/lib/Database/ImportTransaction.cpp
+++ b/lib/Database/ImportTransaction.cpp
@@ -445,9 +445,9 @@ void UnitDataImport::setMainFile(CanonicalFilePathRef mainFile) {
   MainFile = mainFile;
 }
 
-void UnitDataImport::setOutFile(StringRef outFile) {
+void UnitDataImport::setOutFileIdentifier(StringRef outFileIdentifier) {
   assert(!IsUpToDate);
-  OutFile = outFile;
+  OutFileIdentifier = outFileIdentifier;
 }
 
 void UnitDataImport::setSysroot(CanonicalFilePathRef sysroot) {
@@ -543,10 +543,10 @@ void UnitDataImport::commit() {
       import.addFilePath(MainFile);
   }
   IDCode outFileCode;
-  if (!OutFile.empty()) {
-    outFileCode = makeIDCodeFromString(OutFile);
+  if (!OutFileIdentifier.empty()) {
+    outFileCode = makeIDCodeFromString(OutFileIdentifier);
     if (outFileCode != PrevOutFileCode)
-      import.addUnitFileIdentifier(OutFile);
+      import.addUnitFileIdentifier(OutFileIdentifier);
   }
   bool hasSysroot = false;
   IDCode sysrootCode;

--- a/lib/Database/ReadTransaction.cpp
+++ b/lib/Database/ReadTransaction.cpp
@@ -409,10 +409,10 @@ CanonicalFilePath ReadTransaction::Implementation::getFullFilePathFromCode(IDCod
   return CanonicalFilePathRef::getAsCanonicalPath(path);
 }
 
-StringRef ReadTransaction::Implementation::getUnitFileIdentifierFromCode(IDCode filePathCode) {
-  SmallString<128> path;
+std::string ReadTransaction::Implementation::getUnitFileIdentifierFromCode(IDCode filePathCode) {
+  std::string path;
   {
-    llvm::raw_svector_ostream OS(path);
+    llvm::raw_string_ostream OS(path);
     getFullFilePathFromCode(filePathCode, OS);
   }
   return path;
@@ -734,7 +734,7 @@ CanonicalFilePath ReadTransaction::getFullFilePathFromCode(IDCode filePathCode) 
   return Impl->getFullFilePathFromCode(filePathCode);
 }
 
-StringRef ReadTransaction::getUnitFileIdentifierFromCode(IDCode filePathCode) {
+std::string ReadTransaction::getUnitFileIdentifierFromCode(IDCode filePathCode) {
   return Impl->getUnitFileIdentifierFromCode(filePathCode);
 }
 

--- a/lib/Database/ReadTransactionImpl.h
+++ b/lib/Database/ReadTransactionImpl.h
@@ -85,7 +85,7 @@ public:
   CanonicalFilePathRef getDirectoryFromCode(IDCode dirCode);
   /// Returns empty path if it was not found. This should only be used for the unit path since it is not treated as
   ///  a canonicalized path.
-  StringRef getUnitFileIdentifierFromCode(IDCode fileCode);
+  std::string getUnitFileIdentifierFromCode(IDCode fileCode);
   bool foreachDirPath(llvm::function_ref<bool(CanonicalFilePathRef dirPath)> receiver);
   bool findFilePathsWithParentPaths(ArrayRef<CanonicalFilePathRef> parentPaths,
                                     llvm::function_ref<bool(IDCode pathCode, CanonicalFilePathRef filePath)> receiver);


### PR DESCRIPTION
The recent change to out files stored references to stack-allocated strings. Change these to `std::string` instead.

Also do a bunch more renaming to `OutFileIdentifier` while I'm here.