### PR TITLE
Package.swift: bump `swift-tools-version` to 5.5

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.3
+// swift-tools-version:5.5
 
 import PackageDescription
 
@@ -44,7 +44,7 @@ let package = Package(
       dependencies: ["ISDBTibs", "ISDBTestSupport"]),
 
     // Commandline tool for working with tibs projects.
-    .target(
+    .executableTarget(
       name: "tibs",
       dependencies: ["ISDBTibs"]),
 


### PR DESCRIPTION
This allows us to use `executableTarget` for `tibs`, which resolves an issue when building IndexStoreDB with SourceKit-LSP, as the latter also needs `swift-tools-version` to be updated to 5.5. None of the CI nodes seem to be running anything older than Swift 5.5 for a long time already.