### PR TITLE
Add functions to retrieve all tests within a workspace or within a given source file

### DIFF
--- a/Sources/IndexStoreDB/IndexStoreDB.swift
+++ b/Sources/IndexStoreDB/IndexStoreDB.swift
@@ -381,6 +381,28 @@ public final class IndexStoreDB {
       return body(Symbol(symbol))
     }
   }
+
+  /// Returns all unit test symbol in unit files that reference one of the main files in `mainFilePaths`.
+  public func unitTests(referencedByMainFiles mainFilePaths: [String]) -> [SymbolOccurrence] {
+    var result: [SymbolOccurrence] = []
+    let cMainFiles: [UnsafePointer<CChar>] = mainFilePaths.map { UnsafePointer($0.withCString(strdup)!) }
+    defer { for cPath in cMainFiles { free(UnsafeMutablePointer(mutating: cPath)) } }
+    indexstoredb_index_unit_tests_referenced_by_main_files(impl, cMainFiles, cMainFiles.count) { symbol in
+      result.append(SymbolOccurrence(symbol))
+      return true
+    }
+    return result
+  }
+
+  /// Returns all unit test symbols in the index.
+  public func unitTests() -> [SymbolOccurrence] {
+    var result: [SymbolOccurrence] = []
+    indexstoredb_index_unit_tests(impl) { symbol in
+      result.append(SymbolOccurrence(symbol))
+      return true
+    }
+    return result
+  }
 }
 
 public protocol IndexStoreLibraryProvider {

--- a/include/CIndexStoreDB/CIndexStoreDB.h
+++ b/include/CIndexStoreDB/CIndexStoreDB.h
@@ -522,6 +522,36 @@ indexstoredb_index_includes_of_unit(
   const char *_Nonnull unitName,
   _Nonnull indexstoredb_unit_includes_receiver receiver);
 
+/// Calls `receiver` for every unit test symbol in unit files that reference
+/// one of the main files in `mainFilePaths`.
+///
+/// \param index An IndexStoreDB object which contains the symbols.
+/// \param mainFilePaths File paths to search for unit tests
+/// \param count Number of elements in `mainFilePaths`.
+/// \param receiver A function to be called for each unit tests. If the receiver
+/// returns `false`, iteration is stopped and the function returns `true`.
+/// \returns `false` if the receiver returned `false` to stop receiving symbols, `true` otherwise.
+INDEXSTOREDB_PUBLIC bool
+indexstoredb_index_unit_tests_referenced_by_main_files(
+  _Nonnull indexstoredb_index_t index,
+   const char *_Nonnull const *_Nonnull mainFilePaths,
+   size_t count,
+  _Nonnull indexstoredb_symbol_occurrence_receiver_t receiver
+);
+
+/// Calls `receiver` for every unit test symbol in the index.
+///
+/// \param index An IndexStoreDB object which contains the symbols.
+/// \param receiver A function to be called for each unit tests. If the receiver
+/// returns `false`, iteration is stopped and the function returns `true`.
+/// \returns `false` if the receiver returned `false` to stop receiving symbols, `true` otherwise.
+INDEXSTOREDB_PUBLIC bool
+indexstoredb_index_unit_tests(
+  _Nonnull indexstoredb_index_t index,
+  _Nonnull indexstoredb_symbol_occurrence_receiver_t receiver
+);
+
+
 INDEXSTOREDB_END_DECLS
 
 #endif

--- a/include/IndexStoreDB/Index/IndexSystem.h
+++ b/include/IndexStoreDB/Index/IndexSystem.h
@@ -162,6 +162,21 @@ public:
   bool foreachUnitTestSymbolReferencedByOutputPaths(ArrayRef<CanonicalFilePathRef> FilePaths,
       function_ref<bool(SymbolOccurrenceRef Occur)> Receiver);
 
+
+  /// Calls `receiver` for every unit test symbol in unit files that reference
+  /// one of the main files in `mainFilePaths`.
+  ///
+  ///  \returns `false` if the receiver returned `false` to stop receiving symbols, `true` otherwise.
+  bool foreachUnitTestSymbolReferencedByMainFiles(
+      ArrayRef<StringRef> mainFilePaths,
+      function_ref<bool(SymbolOccurrenceRef Occur)> receiver
+  );
+
+  /// Calls `receiver` for every unit test symbol in the index.
+  ///
+  ///  \returns `false` if the receiver returned `false` to stop receiving symbols, `true` otherwise.
+  bool foreachUnitTestSymbol(function_ref<bool(SymbolOccurrenceRef Occur)> receiver);
+
 private:
   IndexSystem(void *Impl) : Impl(Impl) {}
 

--- a/include/IndexStoreDB/Index/SymbolIndex.h
+++ b/include/IndexStoreDB/Index/SymbolIndex.h
@@ -89,6 +89,18 @@ public:
   bool foreachUnitTestSymbolReferencedByOutputPaths(ArrayRef<CanonicalFilePathRef> FilePaths,
       function_ref<bool(SymbolOccurrenceRef Occur)> Receiver);
 
+  /// Calls `receiver` for every unit test symbol in unit files that reference
+  /// one of the main files in `mainFilePaths`.
+  ///
+  ///  \returns `false` if the receiver returned `false` to stop receiving symbols, `true` otherwise.
+  bool foreachUnitTestSymbolReferencedByMainFiles(
+      ArrayRef<CanonicalFilePath> mainFilePaths,
+      function_ref<bool(SymbolOccurrenceRef Occur)> receiver
+  );
+  /// Calls `receiver` for every unit test symbol in the index.
+  ///
+  ///  \returns `false` if the receiver returned `false` to stop receiving symbols, `true` otherwise.
+  bool foreachUnitTestSymbol(function_ref<bool(SymbolOccurrenceRef Occur)> receiver);
 private:
   void *Impl; // A SymbolIndexImpl.
 };

--- a/lib/CIndexStoreDB/CIndexStoreDB.cpp
+++ b/lib/CIndexStoreDB/CIndexStoreDB.cpp
@@ -15,6 +15,7 @@
 #include "IndexStoreDB/Index/IndexStoreLibraryProvider.h"
 #include "IndexStoreDB/Index/IndexSystem.h"
 #include "IndexStoreDB/Index/IndexSystemDelegate.h"
+#include "IndexStoreDB/Support/Path.h"
 #include "IndexStoreDB/Core/Symbol.h"
 #include "indexstore/IndexStoreCXX.h"
 #include "llvm/ADT/IntrusiveRefCntPtr.h"
@@ -595,6 +596,34 @@ indexstoredb_index_includes_of_unit(
   auto obj = (Object<std::shared_ptr<IndexSystem>> *)index;
   return obj->value->foreachIncludeOfUnit(unitName, [&](CanonicalFilePathRef sourcePath, CanonicalFilePathRef targetPath, unsigned line)->bool {
     return receiver(sourcePath.getPath().str().c_str(), targetPath.getPath().str().c_str(), line);
+  });
+}
+
+bool
+indexstoredb_index_unit_tests_referenced_by_main_files(
+  _Nonnull indexstoredb_index_t index,
+   const char *_Nonnull const *_Nonnull cMainFilePaths,
+   size_t count,
+  _Nonnull indexstoredb_symbol_occurrence_receiver_t receiver
+) {
+  auto obj = (Object<std::shared_ptr<IndexSystem>> *)index;
+  SmallVector<StringRef, 2> mainFilePaths;
+  for (size_t i = 0; i < count; ++i) {
+    mainFilePaths.push_back(cMainFilePaths[i]);
+  }
+  return obj->value->foreachUnitTestSymbolReferencedByMainFiles(mainFilePaths, [&](SymbolOccurrenceRef occur) -> bool {
+    return receiver((indexstoredb_symbol_occurrence_t)occur.get());
+  });
+}
+
+bool
+indexstoredb_index_unit_tests(
+  _Nonnull indexstoredb_index_t index,
+  _Nonnull indexstoredb_symbol_occurrence_receiver_t receiver
+) {
+  auto obj = (Object<std::shared_ptr<IndexSystem>> *)index;
+  return obj->value->foreachUnitTestSymbol([&](SymbolOccurrenceRef occur) -> bool {
+    return receiver((indexstoredb_symbol_occurrence_t)occur.get());
   });
 }
 

--- a/lib/Index/IndexSystem.cpp
+++ b/lib/Index/IndexSystem.cpp
@@ -219,6 +219,20 @@ public:
 
   bool foreachUnitTestSymbolReferencedByOutputPaths(ArrayRef<CanonicalFilePathRef> FilePaths,
       function_ref<bool(SymbolOccurrenceRef Occur)> Receiver);
+
+  /// Calls `receiver` for every unit test symbol in unit files that reference
+  /// one of the main files in `mainFilePaths`.
+  ///
+  ///  \returns `false` if the receiver returned `false` to stop receiving symbols, `true` otherwise.
+  bool foreachUnitTestSymbolReferencedByMainFiles(
+      ArrayRef<StringRef> mainFilePaths,
+      function_ref<bool(SymbolOccurrenceRef Occur)> receiver
+  );
+
+  /// Calls `receiver` for every unit test symbol in the index.
+  ///
+  ///  \returns `false` if the receiver returned `false` to stop receiving symbols, `true` otherwise.
+  bool foreachUnitTestSymbol(function_ref<bool(SymbolOccurrenceRef Occur)> receiver);
 };
 
 } // anonymous namespace
@@ -598,6 +612,21 @@ bool IndexSystemImpl::foreachUnitTestSymbolReferencedByOutputPaths(ArrayRef<Cano
   return SymIndex->foreachUnitTestSymbolReferencedByOutputPaths(FilePaths, std::move(Receiver));
 }
 
+bool IndexSystemImpl::foreachUnitTestSymbolReferencedByMainFiles(
+    ArrayRef<StringRef> mainFilePaths,
+    function_ref<bool(SymbolOccurrenceRef Occur)> receiver
+) {
+  std::vector<CanonicalFilePath> canonicalMainFilesPaths;
+  for (StringRef mainFilePath : mainFilePaths) {
+    canonicalMainFilesPaths.push_back(PathIndex->getCanonicalPath(mainFilePath));
+  }
+  return SymIndex->foreachUnitTestSymbolReferencedByMainFiles(canonicalMainFilesPaths, std::move(receiver));
+}
+
+bool IndexSystemImpl::foreachUnitTestSymbol(function_ref<bool(SymbolOccurrenceRef Occur)> receiver) {
+  return SymIndex->foreachUnitTestSymbol(std::move(receiver));
+}
+
 //===----------------------------------------------------------------------===//
 // IndexSystem
 //===----------------------------------------------------------------------===//
@@ -803,4 +832,15 @@ bool IndexSystem::foreachIncludeOfUnit(StringRef unitName,
 bool IndexSystem::foreachUnitTestSymbolReferencedByOutputPaths(ArrayRef<CanonicalFilePathRef> FilePaths,
     function_ref<bool(SymbolOccurrenceRef Occur)> Receiver) {
   return IMPL->foreachUnitTestSymbolReferencedByOutputPaths(FilePaths, std::move(Receiver));
+}
+
+bool IndexSystem::foreachUnitTestSymbolReferencedByMainFiles(
+   ArrayRef<StringRef> mainFilePaths,
+   function_ref<bool(SymbolOccurrenceRef Occur)> receiver
+) {
+  return IMPL->foreachUnitTestSymbolReferencedByMainFiles(mainFilePaths, std::move(receiver));
+}
+
+bool IndexSystem::foreachUnitTestSymbol(function_ref<bool(SymbolOccurrenceRef Occur)> receiver) {
+  return IMPL->foreachUnitTestSymbol(std::move(receiver));
 }


### PR DESCRIPTION
This will be used by sourcekit-lsp to discover test in https://github.com/apple/sourcekit-lsp/pull/978.