### PR TITLE
Avoid a copying the result for `originalFileTrigger`

### DIFF
--- a/include/IndexStoreDB/Index/IndexSystemDelegate.h
+++ b/include/IndexStoreDB/Index/IndexSystemDelegate.h
@@ -27,7 +27,7 @@ namespace index {
 class OutOfDateTriggerHint {
 public:
   virtual ~OutOfDateTriggerHint() {}
-  virtual std::string originalFileTrigger() = 0;
+  virtual StringRef originalFileTrigger() = 0;
   virtual std::string description() = 0;
 
 private:
@@ -45,7 +45,7 @@ public:
     return std::make_shared<DependentFileOutOfDateTriggerHint>(filePath);
   }
 
-  virtual std::string originalFileTrigger() override;
+  virtual StringRef originalFileTrigger() override;
   virtual std::string description() override;
 };
 
@@ -61,7 +61,7 @@ public:
     return std::make_shared<DependentUnitOutOfDateTriggerHint>(unitName, std::move(depHint));
   }
 
-  virtual std::string originalFileTrigger() override;
+  virtual StringRef originalFileTrigger() override;
   virtual std::string description() override;
 };
 

--- a/lib/Index/IndexDatastore.cpp
+++ b/lib/Index/IndexDatastore.cpp
@@ -188,7 +188,7 @@ class UnitMonitor {
     OutOfDateTriggerHintRef hint;
     sys::TimePoint<> outOfDateModTime;
 
-    std::string getTriggerFilePath() const {
+    StringRef getTriggerFilePath() const {
       return hint->originalFileTrigger();
     }
   };

--- a/lib/Index/IndexSystem.cpp
+++ b/lib/Index/IndexSystem.cpp
@@ -604,7 +604,7 @@ bool IndexSystemImpl::foreachUnitTestSymbolReferencedByOutputPaths(ArrayRef<Cano
 
 void OutOfDateTriggerHint::_anchor() {}
 
-std::string DependentFileOutOfDateTriggerHint::originalFileTrigger() {
+StringRef DependentFileOutOfDateTriggerHint::originalFileTrigger() {
   return FilePath;
 }
 
@@ -612,7 +612,7 @@ std::string DependentFileOutOfDateTriggerHint::description() {
   return FilePath;
 }
 
-std::string DependentUnitOutOfDateTriggerHint::originalFileTrigger() {
+StringRef DependentUnitOutOfDateTriggerHint::originalFileTrigger() {
   return DepHint->originalFileTrigger();
 }
 


### PR DESCRIPTION
We can return this as a StringRef, which avoids copying when querying `OutOfDateTriggers`.

rdar://118808681