### PR TITLE
Add API to get the language in which a symbol is defined and the symbol provider for a source file

### DIFF
--- a/Sources/IndexStoreDB/IndexStoreDB.swift
+++ b/Sources/IndexStoreDB/IndexStoreDB.swift
@@ -153,6 +153,10 @@ public final class IndexStoreDB {
     return indexstoredb_index_remove_unit_out_file_paths(impl, cPaths, cPaths.count, waitForProcessing)
   }
 
+  /// Invoke `body` with every occurrance of `usr` in one of the specified roles.
+  ///
+  /// Stop iteration if `body` returns `false`.
+  /// - Returns: `false` if iteration was terminated by `body` returning `true` or `true` if iteration finished.
   @discardableResult
   public func forEachSymbolOccurrence(byUSR usr: String, roles: SymbolRole, _ body: @escaping (SymbolOccurrence) -> Bool) -> Bool {
     return indexstoredb_index_symbol_occurrences_by_usr(impl, usr, roles.rawValue) { occur in
@@ -160,6 +164,7 @@ public final class IndexStoreDB {
     }
   }
 
+  /// Returns all occurrences of `usr` in one of the specified roles.
   public func occurrences(ofUSR usr: String, roles: SymbolRole) -> [SymbolOccurrence] {
     var result: [SymbolOccurrence] = []
     forEachSymbolOccurrence(byUSR: usr, roles: roles) { occur in

--- a/Sources/IndexStoreDB/IndexStoreDB.swift
+++ b/Sources/IndexStoreDB/IndexStoreDB.swift
@@ -35,6 +35,11 @@ public struct PathMapping {
   }
 }
 
+public enum SymbolProviderKind {
+  case clang
+  case swift
+}
+
 /// IndexStoreDB index.
 public final class IndexStoreDB {
 
@@ -275,6 +280,41 @@ public final class IndexStoreDB {
     return result
   }
     
+  public func symbolProvider(for sourceFilePath: String) -> SymbolProviderKind? {
+    var result: SymbolProviderKind? = nil
+    indexstoredb_index_units_containing_file(impl, sourceFilePath) { unit in
+      let providerKind: SymbolProviderKind? = switch indexstoredb_unit_info_symbol_provider_kind(unit) {
+      case INDEXSTOREDB_SYMBOL_PROVIDER_KIND_SWIFT:
+        .swift
+      case INDEXSTOREDB_SYMBOL_PROVIDER_KIND_CLANG:
+        .clang
+      case INDEXSTOREDB_SYMBOL_PROVIDER_KIND_UNKNOWN:
+        nil
+      default:
+        preconditionFailure("Unknown enum case in indexstoredb_symbol_provider_kind_t")
+      }
+
+      let mainFilePath = String(cString: indexstoredb_unit_info_main_file_path(unit))
+      if providerKind == .swift && mainFilePath != sourceFilePath {
+        // We have a unit that is "included" from Swift. This happens for header
+        // files that Swift files depend on. But Swift doesn't have includes and
+        // we shouldn't infer the header file's language to Swift based on this unit.
+        // Ignore it.
+        return true
+      }
+
+      if result == nil {
+        result = providerKind
+      } else if result != providerKind {
+        // Found two conflicting provider kinds. Return nil as we don't know the provider in this case.
+        result = nil
+        return false
+      }
+      return true
+    }
+    return result
+  }
+
   @discardableResult
   public func foreachFileIncludedByFile(path: String, body: @escaping (String) -> Bool) -> Bool {
     return indexstoredb_index_files_included_by_file(impl, path) { targetPath, line in

--- a/Sources/IndexStoreDB/Symbol.swift
+++ b/Sources/IndexStoreDB/Symbol.swift
@@ -45,18 +45,33 @@ public enum IndexSymbolKind: Hashable {
   case commentTag
 }
 
+public enum Language: Hashable {
+  case c
+  case cxx
+  case objc
+  case swift
+}
+
 public struct Symbol: Equatable {
 
   public var usr: String
   public var name: String
   public var kind: IndexSymbolKind
   public var properties: SymbolProperty
+  public var language: Language
 
-  public init(usr: String, name: String, kind: IndexSymbolKind, properties: SymbolProperty = SymbolProperty()) {
+  public init(
+    usr: String,
+    name: String,
+    kind: IndexSymbolKind,
+    properties: SymbolProperty = SymbolProperty(),
+    language: Language
+  ) {
     self.usr = usr
     self.name = name
     self.kind = kind
     self.properties = properties
+    self.language = language
   }
 }
 
@@ -82,9 +97,16 @@ extension Symbol {
     name: String? = nil,
     usr: String? = nil,
     kind: IndexSymbolKind? = nil,
-    properties: SymbolProperty? = nil) -> Symbol
-  {
-    return Symbol(usr: usr ?? self.usr, name: name ?? self.name, kind: kind ?? self.kind, properties: properties ?? self.properties)
+    properties: SymbolProperty? = nil,
+    language: Language? = nil
+  ) -> Symbol {
+    return Symbol(
+      usr: usr ?? self.usr,
+      name: name ?? self.name,
+      kind: kind ?? self.kind,
+      properties: properties ?? self.properties,
+      language: language ?? self.language
+    )
   }
 
   /// Returns a SymbolOccurrence with the given location and roles.
@@ -95,6 +117,23 @@ extension Symbol {
 
 // MARK: CIndexStoreDB conversions
 
+fileprivate extension Language {
+  init(_ value: indexstoredb_language_t) {
+    switch value {
+    case INDEXSTOREDB_LANGUAGE_C:
+      self = .c
+    case INDEXSTOREDB_LANGUAGE_CXX:
+      self = .cxx
+    case INDEXSTOREDB_LANGUAGE_OBJC:
+      self = .objc
+    case INDEXSTOREDB_LANGUAGE_SWIFT:
+      self = .swift
+    default:
+      preconditionFailure("Unhandled case from C enum indexstoredb_language_t")
+    }
+  }
+}
+
 extension Symbol {
 
   /// Note: `value` is expected to be passed +1.
@@ -103,7 +142,9 @@ extension Symbol {
       usr: String(cString: indexstoredb_symbol_usr(value)),
       name: String(cString: indexstoredb_symbol_name(value)),
       kind: IndexSymbolKind(indexstoredb_symbol_kind(value)),
-      properties: SymbolProperty(rawValue: indexstoredb_symbol_properties(value)))
+      properties: SymbolProperty(rawValue: indexstoredb_symbol_properties(value)),
+      language: Language(indexstoredb_symbol_language(value))
+    )
   }
 }
 

--- a/Sources/IndexStoreDB/Symbol.swift
+++ b/Sources/IndexStoreDB/Symbol.swift
@@ -84,9 +84,9 @@ extension Symbol: Comparable {
 extension Symbol: CustomStringConvertible {
   public var description: String {
     if properties.isEmpty {
-      return "\(name) | \(kind) | \(usr)"
+      return "\(name) | \(kind) | \(usr) | \(language)"
     }
-    return "\(name) | \(kind) (\(properties)) | \(usr)"
+    return "\(name) | \(kind) (\(properties)) | \(usr) | \(language)"
   }
 }
 

--- a/Tests/IndexStoreDBTests/IndexTests.swift
+++ b/Tests/IndexStoreDBTests/IndexTests.swift
@@ -113,21 +113,21 @@ final class IndexTests: XCTestCase {
     checkOccurrences(cdeclOccs, expected: [
       cdecl.at(ws.testLoc("C:decl"), roles: [.declaration, .canonical]),
       cdecl.at(ws.testLoc("C:def"), roles: .definition),
-      cdecl.at(ws.testLoc("C:ref:swift"), roles: .reference),
+      cdecl.with(language: .swift).at(ws.testLoc("C:ref:swift"), roles: .reference),
       cdecl.at(ws.testLoc("C:ref:e.mm"), roles: .reference),
     ])
 
     let cmethod = Symbol(usr: "c:objc(cs)C(im)method", name: "method", kind: .instanceMethod, language: .objc)
     let cmethodOccs = index.occurrences(ofUSR: cmethod.usr, roles: .all)
     checkOccurrences(cmethodOccs, expected: [
-      cmethod.with(name: "method()").at(ws.testLoc("C.method:call:swift"), roles: [.call, .dynamic]),
+      cmethod.with(name: "method()", language: .swift).at(ws.testLoc("C.method:call:swift"), roles: [.call, .dynamic]),
       cmethod.at(ws.testLoc("C.method:decl"), roles: .declaration),
       cmethod.at(ws.testLoc("C.method:def"), roles: .definition),
       cmethod.at(ws.testLoc("C.method:call:e.mm"), roles: [.call, .dynamic]),
     ])
   #endif
 
-    let ddecl = Symbol(usr: "c:@S@D", name: "D", kind: .class, language: .c)
+    let ddecl = Symbol(usr: "c:@S@D", name: "D", kind: .class, language: .cxx)
     let dOccs = index.occurrences(ofUSR: ddecl.usr, roles: .all)
     checkOccurrences(dOccs, expected: [
       ddecl.at(ws.testLoc("D:def"), roles: .definition),
@@ -139,7 +139,7 @@ final class IndexTests: XCTestCase {
     let bridgingHeaderOccs = index.occurrences(ofUSR: bhdecl.usr, roles: .all)
     checkOccurrences(bridgingHeaderOccs, expected: [
       bhdecl.at(ws.testLoc("bridgingHeader:decl"), roles: .declaration),
-      bhdecl.with(name: "bridgingHeader()").at(ws.testLoc("bridgingHeader:call"), roles: .call),
+      bhdecl.with(name: "bridgingHeader()", language: .swift).at(ws.testLoc("bridgingHeader:call"), roles: .call),
     ])
   }
 
@@ -154,18 +154,18 @@ final class IndexTests: XCTestCase {
     let index = ws.index
 
   #if os(macOS)
-    let cdecl = Symbol(usr: "c:objc(cs)C", name: "C", kind: .class, language: .c)
+    let cdecl = Symbol(usr: "c:objc(cs)C", name: "C", kind: .class, language: .objc)
     let cdeclOccs = index.occurrences(ofUSR: cdecl.usr, roles: .all)
     checkOccurrences(cdeclOccs, expected: [
       cdecl.at(ws.testLoc("C:decl"), roles: [.declaration, .canonical]),
       cdecl.at(ws.testLoc("C:def"), roles: .definition),
-      cdecl.at(ws.testLoc("C:ref:swift"), roles: .reference),
+      cdecl.with(language: .swift).at(ws.testLoc("C:ref:swift"), roles: .reference),
     ])
 
-    let cmethod = Symbol(usr: "c:objc(cs)C(im)method", name: "method", kind: .instanceMethod, language: .c)
+    let cmethod = Symbol(usr: "c:objc(cs)C(im)method", name: "method", kind: .instanceMethod, language: .objc)
     let cmethodOccs = index.occurrences(ofUSR: cmethod.usr, roles: .all)
     checkOccurrences(cmethodOccs, expected: [
-      cmethod.with(name: "method()").at(ws.testLoc("C.method:call:swift"), roles: [.call, .dynamic]),
+      cmethod.with(name: "method()", language: .swift).at(ws.testLoc("C.method:call:swift"), roles: [.call, .dynamic]),
       cmethod.at(ws.testLoc("C.method:decl"), roles: .declaration),
       cmethod.at(ws.testLoc("C.method:def"), roles: .definition),
     ])
@@ -175,7 +175,7 @@ final class IndexTests: XCTestCase {
     let bridgingHeaderOccs = index.occurrences(ofUSR: bhdecl.usr, roles: .all)
     checkOccurrences(bridgingHeaderOccs, expected: [
       bhdecl.at(ws.testLoc("bridgingHeader:decl"), roles: .declaration),
-      bhdecl.with(name: "bridgingHeader()").at(ws.testLoc("bridgingHeader:call"), roles: .call),
+      bhdecl.with(name: "bridgingHeader()", language: .swift).at(ws.testLoc("bridgingHeader:call"), roles: .call),
     ])
   }
 
@@ -191,7 +191,7 @@ final class IndexTests: XCTestCase {
     let index = ws.index
 
   #if os(macOS)
-    let cdecl = Symbol(usr: "c:objc(cs)C", name: "C", kind: .class, language: .c)
+    let cdecl = Symbol(usr: "c:objc(cs)C", name: "C", kind: .class, language: .objc)
     let getOccs = { index.occurrences(ofUSR: cdecl.usr, roles: .all) }
 
     // Output units are not set yet.
@@ -209,13 +209,13 @@ final class IndexTests: XCTestCase {
     let bridgingHeaderOccs = index.occurrences(ofUSR: bhdecl.usr, roles: .all)
     checkOccurrences(bridgingHeaderOccs, expected: [
       bhdecl.at(ws.testLoc("bridgingHeader:decl"), roles: .declaration),
-      bhdecl.with(name: "bridgingHeader()").at(ws.testLoc("bridgingHeader:call"), roles: .call),
+      bhdecl.with(name: "bridgingHeader()", language: .swift).at(ws.testLoc("bridgingHeader:call"), roles: .call),
     ])
   #if os(macOS)
     checkOccurrences(getOccs(), expected: [
       cdecl.at(ws.testLoc("C:decl"), roles: [.declaration, .canonical]),
       cdecl.at(ws.testLoc("C:def"), roles: .definition),
-      cdecl.at(ws.testLoc("C:ref:swift"), roles: .reference),
+      cdecl.with(language: .swift).at(ws.testLoc("C:ref:swift"), roles: .reference),
     ])
 
     let outUnitASwift = try XCTUnwrap(indexOutputPaths.first{ $0.hasSuffix("-a.swift.o") })
@@ -239,7 +239,7 @@ final class IndexTests: XCTestCase {
     let index = ws.index
 
   #if os(macOS)
-    let cdecl = Symbol(usr: "c:objc(cs)C", name: "C", kind: .class, language: .c)
+    let cdecl = Symbol(usr: "c:objc(cs)C", name: "C", kind: .class, language: .objc)
     let getOccs = { index.occurrences(ofUSR: cdecl.usr, roles: .all) }
 
     // Output units are not set yet.
@@ -257,13 +257,13 @@ final class IndexTests: XCTestCase {
     let bridgingHeaderOccs = index.occurrences(ofUSR: bhdecl.usr, roles: .all)
     checkOccurrences(bridgingHeaderOccs, expected: [
       bhdecl.at(ws.testLoc("bridgingHeader:decl"), roles: .declaration),
-      bhdecl.with(name: "bridgingHeader()").at(ws.testLoc("bridgingHeader:call"), roles: .call),
+      bhdecl.with(name: "bridgingHeader()", language: .swift).at(ws.testLoc("bridgingHeader:call"), roles: .call),
     ])
   #if os(macOS)
     checkOccurrences(getOccs(), expected: [
       cdecl.at(ws.testLoc("C:decl"), roles: [.declaration, .canonical]),
       cdecl.at(ws.testLoc("C:def"), roles: .definition),
-      cdecl.at(ws.testLoc("C:ref:swift"), roles: .reference),
+      cdecl.with(language: .swift).at(ws.testLoc("C:ref:swift"), roles: .reference),
     ])
 
     let outUnitASwift = try XCTUnwrap(indexOutputPaths.first{ $0.hasSuffix("-a.swift.o") })
@@ -547,7 +547,7 @@ final class IndexTests: XCTestCase {
     try ws.buildAndIndex()
     let index = ws.index
 
-    let ddecl = Symbol(usr: "c:@S@D", name: "D", kind: .class, language: .c)
+    let ddecl = Symbol(usr: "c:@S@D", name: "D", kind: .class, language: .cxx)
     let getOccs = { index.occurrences(ofUSR: ddecl.usr, roles: .all) }
 
     // Output units are not set yet.
@@ -573,7 +573,7 @@ final class IndexTests: XCTestCase {
     let bridgingHeaderOccs = index.occurrences(ofUSR: bhdecl.usr, roles: .all)
     checkOccurrences(bridgingHeaderOccs, expected: [
       bhdecl.at(ws.testLoc("bridgingHeader:decl"), roles: .declaration),
-      bhdecl.with(name: "bridgingHeader()").at(ws.testLoc("bridgingHeader:call"), roles: .call),
+      bhdecl.with(name: "bridgingHeader()", language: .swift).at(ws.testLoc("bridgingHeader:call"), roles: .call),
     ])
   }
 
@@ -665,7 +665,7 @@ final class IndexTests: XCTestCase {
 
     try ws.buildAndIndex()
 
-    let largeType = Symbol(usr: "c:@CT@LargeType", name: "LargeType", kind: .concept, language: .cxx)
+    let largeType = Symbol(usr: "c:@CT@LargeType", name: "LargeType", kind: .concept, language: .c)
     let largeTypeOccs = ws.index.occurrences(ofUSR: largeType.usr, roles: .all)
     checkOccurrences(largeTypeOccs, expected: [
       largeType.at(ws.testLoc("LargeType:def"), roles: .definition),

--- a/Tests/IndexStoreDBTests/IndexTests.swift
+++ b/Tests/IndexStoreDBTests/IndexTests.swift
@@ -41,8 +41,8 @@ final class IndexTests: XCTestCase {
 
     try ws.buildAndIndex()
 
-    let csym = Symbol(usr: usr, name: "c()", kind: .function)
-    let asym = Symbol(usr: "s:4main1ayyF", name: "a()", kind: .function)
+    let csym = Symbol(usr: usr, name: "c()", kind: .function, language: .swift)
+    let asym = Symbol(usr: "s:4main1ayyF", name: "a()", kind: .function, language: .swift)
 
     let ccanon = SymbolOccurrence(
       symbol: csym,
@@ -92,7 +92,7 @@ final class IndexTests: XCTestCase {
     [
       ccall,
       SymbolOccurrence(
-        symbol: Symbol(usr: "s:4main1byyF", name: "b()", kind: .function),
+        symbol: Symbol(usr: "s:4main1byyF", name: "b()", kind: .function, language: .swift),
         location: SymbolLocation(ws.testLoc("b:call")),
         roles: [.reference, .call, .calledBy, .containedBy],
         relations: [
@@ -108,7 +108,7 @@ final class IndexTests: XCTestCase {
 
   #if os(macOS)
 
-    let cdecl = Symbol(usr: "c:objc(cs)C", name: "C", kind: .class)
+    let cdecl = Symbol(usr: "c:objc(cs)C", name: "C", kind: .class, language: .objc)
     let cdeclOccs = index.occurrences(ofUSR: cdecl.usr, roles: .all)
     checkOccurrences(cdeclOccs, expected: [
       cdecl.at(ws.testLoc("C:decl"), roles: [.declaration, .canonical]),
@@ -117,7 +117,7 @@ final class IndexTests: XCTestCase {
       cdecl.at(ws.testLoc("C:ref:e.mm"), roles: .reference),
     ])
 
-    let cmethod = Symbol(usr: "c:objc(cs)C(im)method", name: "method", kind: .instanceMethod)
+    let cmethod = Symbol(usr: "c:objc(cs)C(im)method", name: "method", kind: .instanceMethod, language: .objc)
     let cmethodOccs = index.occurrences(ofUSR: cmethod.usr, roles: .all)
     checkOccurrences(cmethodOccs, expected: [
       cmethod.with(name: "method()").at(ws.testLoc("C.method:call:swift"), roles: [.call, .dynamic]),
@@ -127,7 +127,7 @@ final class IndexTests: XCTestCase {
     ])
   #endif
 
-    let ddecl = Symbol(usr: "c:@S@D", name: "D", kind: .class)
+    let ddecl = Symbol(usr: "c:@S@D", name: "D", kind: .class, language: .c)
     let dOccs = index.occurrences(ofUSR: ddecl.usr, roles: .all)
     checkOccurrences(dOccs, expected: [
       ddecl.at(ws.testLoc("D:def"), roles: .definition),
@@ -135,7 +135,7 @@ final class IndexTests: XCTestCase {
       ddecl.at(ws.testLoc("D:ref:e.mm"), roles: .reference),
     ])
 
-    let bhdecl = Symbol(usr: "c:@F@bridgingHeader", name: "bridgingHeader", kind: .function)
+    let bhdecl = Symbol(usr: "c:@F@bridgingHeader", name: "bridgingHeader", kind: .function, language: .c)
     let bridgingHeaderOccs = index.occurrences(ofUSR: bhdecl.usr, roles: .all)
     checkOccurrences(bridgingHeaderOccs, expected: [
       bhdecl.at(ws.testLoc("bridgingHeader:decl"), roles: .declaration),
@@ -154,7 +154,7 @@ final class IndexTests: XCTestCase {
     let index = ws.index
 
   #if os(macOS)
-    let cdecl = Symbol(usr: "c:objc(cs)C", name: "C", kind: .class)
+    let cdecl = Symbol(usr: "c:objc(cs)C", name: "C", kind: .class, language: .c)
     let cdeclOccs = index.occurrences(ofUSR: cdecl.usr, roles: .all)
     checkOccurrences(cdeclOccs, expected: [
       cdecl.at(ws.testLoc("C:decl"), roles: [.declaration, .canonical]),
@@ -162,7 +162,7 @@ final class IndexTests: XCTestCase {
       cdecl.at(ws.testLoc("C:ref:swift"), roles: .reference),
     ])
 
-    let cmethod = Symbol(usr: "c:objc(cs)C(im)method", name: "method", kind: .instanceMethod)
+    let cmethod = Symbol(usr: "c:objc(cs)C(im)method", name: "method", kind: .instanceMethod, language: .c)
     let cmethodOccs = index.occurrences(ofUSR: cmethod.usr, roles: .all)
     checkOccurrences(cmethodOccs, expected: [
       cmethod.with(name: "method()").at(ws.testLoc("C.method:call:swift"), roles: [.call, .dynamic]),
@@ -171,7 +171,7 @@ final class IndexTests: XCTestCase {
     ])
   #endif
 
-    let bhdecl = Symbol(usr: "c:@F@bridgingHeader", name: "bridgingHeader", kind: .function)
+    let bhdecl = Symbol(usr: "c:@F@bridgingHeader", name: "bridgingHeader", kind: .function, language: .c)
     let bridgingHeaderOccs = index.occurrences(ofUSR: bhdecl.usr, roles: .all)
     checkOccurrences(bridgingHeaderOccs, expected: [
       bhdecl.at(ws.testLoc("bridgingHeader:decl"), roles: .declaration),
@@ -191,7 +191,7 @@ final class IndexTests: XCTestCase {
     let index = ws.index
 
   #if os(macOS)
-    let cdecl = Symbol(usr: "c:objc(cs)C", name: "C", kind: .class)
+    let cdecl = Symbol(usr: "c:objc(cs)C", name: "C", kind: .class, language: .c)
     let getOccs = { index.occurrences(ofUSR: cdecl.usr, roles: .all) }
 
     // Output units are not set yet.
@@ -205,7 +205,7 @@ final class IndexTests: XCTestCase {
     index.addUnitOutFilePaths(indexOutputPaths, waitForProcessing: true)
 
     // The bridging header is referenced as a PCH unit dependency, make sure we can see the data.
-    let bhdecl = Symbol(usr: "c:@F@bridgingHeader", name: "bridgingHeader", kind: .function)
+    let bhdecl = Symbol(usr: "c:@F@bridgingHeader", name: "bridgingHeader", kind: .function, language: .c)
     let bridgingHeaderOccs = index.occurrences(ofUSR: bhdecl.usr, roles: .all)
     checkOccurrences(bridgingHeaderOccs, expected: [
       bhdecl.at(ws.testLoc("bridgingHeader:decl"), roles: .declaration),
@@ -239,7 +239,7 @@ final class IndexTests: XCTestCase {
     let index = ws.index
 
   #if os(macOS)
-    let cdecl = Symbol(usr: "c:objc(cs)C", name: "C", kind: .class)
+    let cdecl = Symbol(usr: "c:objc(cs)C", name: "C", kind: .class, language: .c)
     let getOccs = { index.occurrences(ofUSR: cdecl.usr, roles: .all) }
 
     // Output units are not set yet.
@@ -253,7 +253,7 @@ final class IndexTests: XCTestCase {
     index.addUnitOutFilePaths(indexOutputPaths, waitForProcessing: true)
 
     // The bridging header is referenced as a PCH unit dependency, make sure we can see the data.
-    let bhdecl = Symbol(usr: "c:@F@bridgingHeader", name: "bridgingHeader", kind: .function)
+    let bhdecl = Symbol(usr: "c:@F@bridgingHeader", name: "bridgingHeader", kind: .function, language: .c)
     let bridgingHeaderOccs = index.occurrences(ofUSR: bhdecl.usr, roles: .all)
     checkOccurrences(bridgingHeaderOccs, expected: [
       bhdecl.at(ws.testLoc("bridgingHeader:decl"), roles: .declaration),
@@ -279,7 +279,7 @@ final class IndexTests: XCTestCase {
     guard let ws = try staticTibsTestWorkspace(name: "SwiftModules") else { return }
     try ws.buildAndIndex()
 
-    let aaa = Symbol(usr: "s:1A3aaayyF", name: "aaa()", kind: .function)
+    let aaa = Symbol(usr: "s:1A3aaayyF", name: "aaa()", kind: .function, language: .swift)
     checkOccurrences(ws.index.occurrences(ofUSR: aaa.usr, roles: .all), expected: [
       aaa.at(ws.testLoc("aaa:def"), moduleName: "A", roles: .definition),
       aaa.at(ws.testLoc("aaa:call"), moduleName: "B", roles: .call),
@@ -291,7 +291,7 @@ final class IndexTests: XCTestCase {
     guard let ws = try mutableTibsTestWorkspace(name: "proj1") else { return }
     try ws.buildAndIndex()
 
-    let cdecl = Symbol(usr: "s:4main1cyyF", name: "c()", kind: .function)
+    let cdecl = Symbol(usr: "s:4main1cyyF", name: "c()", kind: .function, language: .swift)
     let roles: SymbolRole = [.reference, .definition, .declaration]
 
     checkOccurrences(ws.index.occurrences(ofUSR: cdecl.usr, roles: .all), expected: [
@@ -348,7 +348,7 @@ final class IndexTests: XCTestCase {
       waitUntilDoneInitializing: true,
       listenToUnitEvents: true)
 
-    let csym = Symbol(usr: "s:4main1cyyF", name: "c()", kind: .function)
+    let csym = Symbol(usr: "s:4main1cyyF", name: "c()", kind: .function, language: .swift)
     let waitOccs = indexWait.occurrences(ofUSR: csym.usr, roles: [.reference, .definition])
 
     checkOccurrences(waitOccs, expected: [
@@ -547,7 +547,7 @@ final class IndexTests: XCTestCase {
     try ws.buildAndIndex()
     let index = ws.index
 
-    let ddecl = Symbol(usr: "c:@S@D", name: "D", kind: .class)
+    let ddecl = Symbol(usr: "c:@S@D", name: "D", kind: .class, language: .c)
     let getOccs = { index.occurrences(ofUSR: ddecl.usr, roles: .all) }
 
     // Output units are not set yet.
@@ -569,7 +569,7 @@ final class IndexTests: XCTestCase {
     ])
 
     // The bridging header is referenced as a PCH unit dependency, make sure we can see the data.
-    let bhdecl = Symbol(usr: "c:@F@bridgingHeader", name: "bridgingHeader", kind: .function)
+    let bhdecl = Symbol(usr: "c:@F@bridgingHeader", name: "bridgingHeader", kind: .function, language: .c)
     let bridgingHeaderOccs = index.occurrences(ofUSR: bhdecl.usr, roles: .all)
     checkOccurrences(bridgingHeaderOccs, expected: [
       bhdecl.at(ws.testLoc("bridgingHeader:decl"), roles: .declaration),
@@ -634,25 +634,25 @@ final class IndexTests: XCTestCase {
 
     try ws.buildAndIndex()
 
-    let asyncFuncSym = Symbol(usr: "s:4main9asyncFuncyyYaF", name: "asyncFunc()", kind: .function, properties: .swiftAsync)
+    let asyncFuncSym = Symbol(usr: "s:4main9asyncFuncyyYaF", name: "asyncFunc()", kind: .function, properties: .swiftAsync, language: .swift)
     let asyncFuncOccs = index.occurrences(ofUSR: asyncFuncSym.usr, roles: .definition)
     checkOccurrences(asyncFuncOccs, expected: [
       asyncFuncSym.at(ws.testLoc("asyncFunc:def"), roles: .definition)
     ])
 
-    let asyncMethSym = Symbol(usr: "s:4main8MyStructV11asyncMethodyyYaF", name: "asyncMethod()", kind: .instanceMethod, properties: .swiftAsync)
+    let asyncMethSym = Symbol(usr: "s:4main8MyStructV11asyncMethodyyYaF", name: "asyncMethod()", kind: .instanceMethod, properties: .swiftAsync, language: .swift)
     let asyncMethOccs = index.occurrences(ofUSR: asyncMethSym.usr, roles: .definition)
     checkOccurrences(asyncMethOccs, expected: [
       asyncMethSym.at(ws.testLoc("asyncMethod:def"), roles: .definition)
     ])
 
-    let testMeSym = Symbol(usr: "s:4main10MyTestCaseC6testMeyyF", name: "testMe()", kind: .instanceMethod, properties: .unitTest)
+    let testMeSym = Symbol(usr: "s:4main10MyTestCaseC6testMeyyF", name: "testMe()", kind: .instanceMethod, properties: .unitTest, language: .swift)
     let testMeOccs = index.occurrences(ofUSR: testMeSym.usr, roles: .definition)
     checkOccurrences(testMeOccs, expected: [
       testMeSym.at(ws.testLoc("testMe:def"), roles: .definition)
     ])
 
-    let testMeAsyncSym = Symbol(usr: "s:4main10MyTestCaseC11testMeAsyncyyYaF", name: "testMeAsync()", kind: .instanceMethod, properties: [.unitTest, .swiftAsync])
+    let testMeAsyncSym = Symbol(usr: "s:4main10MyTestCaseC11testMeAsyncyyYaF", name: "testMeAsync()", kind: .instanceMethod, properties: [.unitTest, .swiftAsync], language: .swift)
     let testMeAsyncOccs = index.occurrences(ofUSR: testMeAsyncSym.usr, roles: .definition)
     checkOccurrences(testMeAsyncOccs, expected: [
       testMeAsyncSym.at(ws.testLoc("testMeAsync:def"), roles: .definition)
@@ -665,7 +665,7 @@ final class IndexTests: XCTestCase {
 
     try ws.buildAndIndex()
 
-    let largeType = Symbol(usr: "c:@CT@LargeType", name: "LargeType", kind: .concept)
+    let largeType = Symbol(usr: "c:@CT@LargeType", name: "LargeType", kind: .concept, language: .cxx)
     let largeTypeOccs = ws.index.occurrences(ofUSR: largeType.usr, roles: .all)
     checkOccurrences(largeTypeOccs, expected: [
       largeType.at(ws.testLoc("LargeType:def"), roles: .definition),

--- a/include/CIndexStoreDB/CIndexStoreDB.h
+++ b/include/CIndexStoreDB/CIndexStoreDB.h
@@ -137,6 +137,13 @@ typedef enum {
   INDEXSTOREDB_EVENT_UNIT_OUT_OF_DATE = 2,
 } indexstoredb_delegate_event_kind_t;
 
+typedef enum {
+  INDEXSTOREDB_LANGUAGE_C,
+  INDEXSTOREDB_LANGUAGE_OBJC,
+  INDEXSTOREDB_LANGUAGE_CXX,
+  INDEXSTOREDB_LANGUAGE_SWIFT
+} indexstoredb_language_t;
+
 typedef void *indexstoredb_delegate_event_t;
 
 /// Returns true on success.
@@ -332,6 +339,10 @@ indexstoredb_symbol_name(_Nonnull indexstoredb_symbol_t);
 /// Returns the properties of the given symbol.
 INDEXSTOREDB_PUBLIC uint64_t
 indexstoredb_symbol_properties(_Nonnull indexstoredb_symbol_t);
+
+/// Return the language in which the given symbol is defined.
+indexstoredb_language_t
+indexstoredb_symbol_language(_Nonnull indexstoredb_symbol_t symbol);
 
 /// Returns the symbol of the given symbol occurrence.
 ///

--- a/include/CIndexStoreDB/CIndexStoreDB.h
+++ b/include/CIndexStoreDB/CIndexStoreDB.h
@@ -144,6 +144,12 @@ typedef enum {
   INDEXSTOREDB_LANGUAGE_SWIFT
 } indexstoredb_language_t;
 
+typedef enum {
+  INDEXSTOREDB_SYMBOL_PROVIDER_KIND_CLANG,
+  INDEXSTOREDB_SYMBOL_PROVIDER_KIND_SWIFT,
+  INDEXSTOREDB_SYMBOL_PROVIDER_KIND_UNKNOWN,
+} indexstoredb_symbol_provider_kind_t;
+
 typedef void *indexstoredb_delegate_event_t;
 
 /// Returns true on success.
@@ -482,6 +488,9 @@ indexstoredb_unit_info_main_file_path(_Nonnull indexstoredb_unit_info_t);
 /// Returns the unit name of a unit info object.
 INDEXSTOREDB_PUBLIC const char *_Nonnull
 indexstoredb_unit_info_unit_name(_Nonnull indexstoredb_unit_info_t);
+
+INDEXSTOREDB_PUBLIC indexstoredb_symbol_provider_kind_t
+indexstoredb_unit_info_symbol_provider_kind(_Nonnull indexstoredb_unit_info_t info);
 
 /// Iterates over the compilation units that contain \p path and return their units.
 ///

--- a/include/IndexStoreDB/Index/StoreUnitInfo.h
+++ b/include/IndexStoreDB/Index/StoreUnitInfo.h
@@ -13,6 +13,7 @@
 #ifndef INDEXSTOREDB_INDEX_STOREUNITINFO_H
 #define INDEXSTOREDB_INDEX_STOREUNITINFO_H
 
+#include "IndexStoreDB/Core/Symbol.h"
 #include "IndexStoreDB/Support/Path.h"
 #include "llvm/Support/Chrono.h"
 #include <string>
@@ -26,16 +27,18 @@ struct StoreUnitInfo {
   std::string OutFileIdentifier;
   bool HasTestSymbols = false;
   llvm::sys::TimePoint<> ModTime;
+  Optional<SymbolProviderKind> SymProviderKind;
 
   StoreUnitInfo() = default;
   StoreUnitInfo(std::string unitName, CanonicalFilePath mainFilePath,
                 StringRef outFileIdentifier, bool hasTestSymbols,
-                llvm::sys::TimePoint<> modTime)
+                llvm::sys::TimePoint<> modTime, Optional
+                <SymbolProviderKind> SymProviderKind)
       : UnitName(unitName),
         MainFilePath(mainFilePath),
         OutFileIdentifier(outFileIdentifier),
         HasTestSymbols(hasTestSymbols),
-        ModTime(modTime) {}
+        ModTime(modTime), SymProviderKind(SymProviderKind) {}
 };
 
 } // namespace index

--- a/lib/CIndexStoreDB/CIndexStoreDB.cpp
+++ b/lib/CIndexStoreDB/CIndexStoreDB.cpp
@@ -319,6 +319,21 @@ indexstoredb_symbol_usr(indexstoredb_symbol_t symbol) {
   return value->getUSR().c_str();
 }
 
+indexstoredb_language_t
+indexstoredb_symbol_language(_Nonnull indexstoredb_symbol_t symbol) {
+  auto value = (Symbol *)symbol;
+  switch (value->getLanguage()) {
+  case IndexStoreDB::SymbolLanguage::C:
+    return INDEXSTOREDB_LANGUAGE_C;
+  case IndexStoreDB::SymbolLanguage::ObjC:
+    return INDEXSTOREDB_LANGUAGE_OBJC;
+  case IndexStoreDB::SymbolLanguage::CXX:
+    return INDEXSTOREDB_LANGUAGE_CXX;
+  case IndexStoreDB::SymbolLanguage::Swift:
+    return INDEXSTOREDB_LANGUAGE_SWIFT;
+  }
+}
+
 const char *
 indexstoredb_symbol_name(indexstoredb_symbol_t symbol) {
   auto value = (Symbol *)symbol;

--- a/lib/CIndexStoreDB/CIndexStoreDB.cpp
+++ b/lib/CIndexStoreDB/CIndexStoreDB.cpp
@@ -566,6 +566,20 @@ indexstoredb_unit_info_unit_name(indexstoredb_unit_info_t info) {
   return obj->UnitName.c_str();
 }
 
+indexstoredb_symbol_provider_kind_t
+indexstoredb_unit_info_symbol_provider_kind(_Nonnull indexstoredb_unit_info_t info) {
+  auto obj = (const StoreUnitInfo *)info;
+  if (!obj->SymProviderKind) {
+    return INDEXSTOREDB_SYMBOL_PROVIDER_KIND_UNKNOWN;
+  }
+  switch (*obj->SymProviderKind) {
+  case IndexStoreDB::SymbolProviderKind::Clang:
+    return INDEXSTOREDB_SYMBOL_PROVIDER_KIND_CLANG;
+  case IndexStoreDB::SymbolProviderKind::Swift:
+    return INDEXSTOREDB_SYMBOL_PROVIDER_KIND_SWIFT;
+  }
+}
+
 bool
 indexstoredb_index_units_containing_file(
   indexstoredb_index_t index,

--- a/lib/Index/FilePathIndex.cpp
+++ b/lib/Index/FilePathIndex.cpp
@@ -166,6 +166,7 @@ bool FileIndexImpl::foreachMainUnitContainingFile(CanonicalFilePathRef filePath,
       currUnit.ModTime = unitInfo.ModTime;
       currUnit.MainFilePath = reader.getFullFilePathFromCode(unitInfo.MainFileCode);
       currUnit.OutFileIdentifier = reader.getUnitFileIdentifierFromCode(unitInfo.OutFileCode);
+      currUnit.SymProviderKind = unitInfo.SymProviderKind;
       return true;
     });
   }


### PR DESCRIPTION
This will be used by sourcekit-lsp’s cross-file rename.