### PR TITLE
Reduce memory consumption for OutOfDateTriggerHints

### DIFF
--- a/lib/CIndexStoreDB/CIndexStoreDB.cpp
+++ b/lib/CIndexStoreDB/CIndexStoreDB.cpp
@@ -80,17 +80,18 @@ public:
     callback(&event);
   }
 
-  void unitIsOutOfDate(StoreUnitInfo unitInfo,
-                       llvm::sys::TimePoint<> outOfDateModTime,
-                       OutOfDateTriggerHintRef hint,
+  void unitIsOutOfDate(StoreUnitInfo unitInfo, OutOfDateFileTriggerRef trigger,
                        bool synchronous) override {
-    DelegateEvent event{INDEXSTOREDB_EVENT_UNIT_OUT_OF_DATE, 0,
-      &unitInfo,
-      (uint64_t)std::chrono::duration_cast<std::chrono::nanoseconds>(outOfDateModTime.time_since_epoch()).count(),
-      hint->originalFileTrigger(),
-      hint->description(),
-      synchronous
-    };
+    DelegateEvent event{
+        INDEXSTOREDB_EVENT_UNIT_OUT_OF_DATE,
+        0,
+        &unitInfo,
+        (uint64_t)std::chrono::duration_cast<std::chrono::nanoseconds>(
+            trigger->getModTime().time_since_epoch())
+            .count(),
+        trigger->getPath(),
+        trigger->description(),
+        synchronous};
     callback(&event);
   }
 };

--- a/lib/Index/IndexSystem.cpp
+++ b/lib/Index/IndexSystem.cpp
@@ -95,20 +95,19 @@ private:
   }
 
   virtual void unitIsOutOfDate(StoreUnitInfo unitInfo,
-                               llvm::sys::TimePoint<> outOfDateModTime,
-                               OutOfDateTriggerHintRef hint,
+                               OutOfDateFileTriggerRef trigger,
                                bool synchronous) override {
     if (synchronous) {
       Queue.dispatchSync([&]{
         for (auto &other : Others)
-          other->unitIsOutOfDate(std::move(unitInfo), outOfDateModTime, hint, true);
+          other->unitIsOutOfDate(std::move(unitInfo), trigger, true);
       });
       return;
     }
 
     Queue.dispatch([=]{
       for (auto &other : Others)
-        other->unitIsOutOfDate(std::move(unitInfo), outOfDateModTime, hint, false);
+        other->unitIsOutOfDate(std::move(unitInfo), trigger, false);
     });
   }
 
@@ -630,27 +629,6 @@ bool IndexSystemImpl::foreachUnitTestSymbol(function_ref<bool(SymbolOccurrenceRe
 //===----------------------------------------------------------------------===//
 // IndexSystem
 //===----------------------------------------------------------------------===//
-
-void OutOfDateTriggerHint::_anchor() {}
-
-std::string DependentFileOutOfDateTriggerHint::originalFileTrigger() {
-  return FilePath;
-}
-
-std::string DependentFileOutOfDateTriggerHint::description() {
-  return FilePath;
-}
-
-std::string DependentUnitOutOfDateTriggerHint::originalFileTrigger() {
-  return DepHint->originalFileTrigger();
-}
-
-std::string DependentUnitOutOfDateTriggerHint::description() {
-  std::string desc;
-  llvm::raw_string_ostream OS(desc);
-  OS << "unit(" << UnitName << ") -> " << DepHint->description();
-  return desc;
-}
 
 void IndexSystemDelegate::anchor() {}
 


### PR DESCRIPTION
Remove `DependentUnitOutOfDateTriggerHint`, and collapse the class hierarchy into a single class `OutOfDateFileTrigger`, which stores both the file name as well as the mod time. Then, change the `OutOfDateTriggers` map in UnitMonitor to use StringRef keys. This significantly reduces memory consumption for large projects. We could likely go further here by eliminating the storing of triggers completely, but I'm leaving that as future work for now.

rdar://50929788