### PR TITLE
Add an APIs to get the date at which the unit file that produced `SymbolLocation` was modified and the latest modification date of a unit that contains a given source file

### DIFF
--- a/Sources/ISDBTestSupport/TestLocation.swift
+++ b/Sources/ISDBTestSupport/TestLocation.swift
@@ -51,6 +51,7 @@ extension SymbolLocation {
   public init(_ loc: TestLocation, moduleName: String = TestLocation.unknownModuleName, isSystem: Bool = false) {
     self.init(
       path: loc.url.path,
+      timestamp: Date(),
       moduleName: moduleName,
       isSystem: isSystem,
       line: loc.line,

--- a/Sources/IndexStoreDB/IndexStoreDB.swift
+++ b/Sources/IndexStoreDB/IndexStoreDB.swift
@@ -12,6 +12,7 @@
 
 @_implementationOnly
 import CIndexStoreDB
+import Foundation
 
 // For `strdup`
 #if canImport(Glibc)
@@ -447,6 +448,19 @@ public final class IndexStoreDB {
       return true
     }
     return result
+  }
+
+  /// Returns the latest modification date of a unit that contains the given source file.
+  /// 
+  /// If no unit containing the given source file exists, returns `nil`.
+  public func dateOfLatestUnitFor(filePath: String) -> Date? {
+    let timestamp = filePath.withCString { filePathCString in
+      indexstoredb_timestamp_of_latest_unit_for_file(impl, filePathCString)
+    }
+    if timestamp == 0 {
+      return nil
+    }
+    return Date(timeIntervalSince1970: timestamp)
   }
 }
 

--- a/Sources/IndexStoreDB/SymbolLocation.swift
+++ b/Sources/IndexStoreDB/SymbolLocation.swift
@@ -12,16 +12,20 @@
 
 @_implementationOnly
 import CIndexStoreDB
+import Foundation
 
 public struct SymbolLocation: Equatable {
   public var path: String
+  /// The date at which the unit file that contains a symbol has last been modified.
+  public var timestamp: Date
   public var moduleName: String
   public var isSystem: Bool
   public var line: Int
   public var utf8Column: Int
 
-  public init(path: String, moduleName: String, isSystem: Bool = false, line: Int, utf8Column: Int) {
+  public init(path: String, timestamp: Date, moduleName: String, isSystem: Bool = false, line: Int, utf8Column: Int) {
     self.path = path
+    self.timestamp = timestamp
     self.moduleName = moduleName
     self.isSystem = isSystem
     self.line = line
@@ -47,6 +51,7 @@ extension SymbolLocation: CustomStringConvertible {
 extension SymbolLocation {
   internal init(_ loc: indexstoredb_symbol_location_t) {
     path = String(cString: indexstoredb_symbol_location_path(loc))
+    timestamp = Date(timeIntervalSince1970: indexstoredb_symbol_location_timestamp(loc))
     moduleName = String(cString: indexstoredb_symbol_location_module_name(loc))
     isSystem = indexstoredb_symbol_location_is_system(loc)
     line = Int(indexstoredb_symbol_location_line(loc))

--- a/include/CIndexStoreDB/CIndexStoreDB.h
+++ b/include/CIndexStoreDB/CIndexStoreDB.h
@@ -375,6 +375,12 @@ INDEXSTOREDB_PUBLIC
 const char * _Nonnull
 indexstoredb_symbol_location_path(_Nonnull indexstoredb_symbol_location_t);
 
+/// Returns a Unix timestamp (seconds since 1/1/1970) at which the unit file that contains a symbol has last been 
+/// modified.
+INDEXSTOREDB_PUBLIC
+double
+indexstoredb_symbol_location_timestamp(_Nonnull indexstoredb_symbol_location_t loc);
+
 /// Returns the module name of the given symbol location.
 ///
 /// The string has the same lifetime as the \c indexstoredb_symbol_location_t.

--- a/include/CIndexStoreDB/CIndexStoreDB.h
+++ b/include/CIndexStoreDB/CIndexStoreDB.h
@@ -577,6 +577,14 @@ indexstoredb_index_unit_tests(
   _Nonnull indexstoredb_symbol_occurrence_receiver_t receiver
 );
 
+/// Returns a Unix timestamp (seconds since 1/1/1970) of the latest unit that contains the given source file.
+/// 
+/// If no unit containing the given source file exists, returns 0.
+INDEXSTOREDB_PUBLIC double
+indexstoredb_timestamp_of_latest_unit_for_file(
+  _Nonnull indexstoredb_index_t index,
+  const char *_Nonnull fileName
+);
 
 INDEXSTOREDB_END_DECLS
 

--- a/include/IndexStoreDB/Index/IndexSystem.h
+++ b/include/IndexStoreDB/Index/IndexSystem.h
@@ -177,6 +177,10 @@ public:
   ///  \returns `false` if the receiver returned `false` to stop receiving symbols, `true` otherwise.
   bool foreachUnitTestSymbol(function_ref<bool(SymbolOccurrenceRef Occur)> receiver);
 
+  /// Returns the latest modification date of a unit that contains the given source file.
+  /// 
+  /// If no unit containing the given source file exists, returns `None`.
+  llvm::Optional<llvm::sys::TimePoint<>> timestampOfLatestUnitForFile(StringRef filePath);
 private:
   IndexSystem(void *Impl) : Impl(Impl) {}
 

--- a/include/IndexStoreDB/Index/SymbolIndex.h
+++ b/include/IndexStoreDB/Index/SymbolIndex.h
@@ -15,6 +15,7 @@
 
 #include "IndexStoreDB/Support/LLVM.h"
 #include "llvm/ADT/OptionSet.h"
+#include "llvm/Support/Chrono.h"
 #include <memory>
 
 namespace indexstore {
@@ -101,6 +102,11 @@ public:
   ///
   ///  \returns `false` if the receiver returned `false` to stop receiving symbols, `true` otherwise.
   bool foreachUnitTestSymbol(function_ref<bool(SymbolOccurrenceRef Occur)> receiver);
+
+  /// Returns the latest modification date of a unit that contains the given source file.
+  /// 
+  /// If no unit containing the given source file exists, returns `None`.
+  llvm::Optional<llvm::sys::TimePoint<>> timestampOfLatestUnitForFile(CanonicalFilePathRef filePath);
 private:
   void *Impl; // A SymbolIndexImpl.
 };

--- a/lib/CIndexStoreDB/CIndexStoreDB.cpp
+++ b/lib/CIndexStoreDB/CIndexStoreDB.cpp
@@ -667,4 +667,21 @@ indexstoredb_index_unit_tests(
   });
 }
 
+INDEXSTOREDB_PUBLIC double
+indexstoredb_timestamp_of_latest_unit_for_file(
+  _Nonnull indexstoredb_index_t index,
+  const char *_Nonnull fileName
+) {
+  auto obj = (Object<std::shared_ptr<IndexSystem>> *)index;
+  llvm::Optional<llvm::sys::TimePoint<>> timePoint = obj->value->timestampOfLatestUnitForFile(fileName);
+  if (timePoint) {
+    // Up until C++20 the reference date of time_since_epoch is undefined but according to 
+    // https://en.cppreference.com/w/cpp/chrono/system_clock most implementations use Unix Time.
+    // Since C++20, system_clock is defined to measure time since 1/1/1970.
+    // We rely on `time_since_epoch` always returning the nanoseconds since 1/1/1970.
+    return timePoint->time_since_epoch().count();
+  }
+  return 0;
+} 
+
 ObjectBase::~ObjectBase() {}

--- a/lib/CIndexStoreDB/CIndexStoreDB.cpp
+++ b/lib/CIndexStoreDB/CIndexStoreDB.cpp
@@ -444,6 +444,17 @@ indexstoredb_symbol_location_path(indexstoredb_symbol_location_t loc) {
   return obj->getPath().getPathString().c_str();
 }
 
+double
+indexstoredb_symbol_location_timestamp(indexstoredb_symbol_location_t loc) {
+  auto obj = (SymbolLocation *)loc;
+  // Up until C++20 the reference date of time_since_epoch is undefined but according to 
+  // https://en.cppreference.com/w/cpp/chrono/system_clock most implementations use Unix Time.
+  // Since C++20, system_clock is defined to measure time since 1/1/1970.
+  // We rely on `time_since_epoch` always returning the nanoseconds since 1/1/1970.
+  auto nanosecondsSinceEpoch = obj->getPath().getModificationTime().time_since_epoch().count();
+  return static_cast<double>(nanosecondsSinceEpoch) / 1000 / 1000 / 1000;
+}
+
 const char *
 indexstoredb_symbol_location_module_name(indexstoredb_symbol_location_t loc) {
   auto obj = (SymbolLocation *)loc;

--- a/lib/Index/IndexSystem.cpp
+++ b/lib/Index/IndexSystem.cpp
@@ -233,6 +233,11 @@ public:
   ///
   ///  \returns `false` if the receiver returned `false` to stop receiving symbols, `true` otherwise.
   bool foreachUnitTestSymbol(function_ref<bool(SymbolOccurrenceRef Occur)> receiver);
+
+  /// Returns the latest modification date of a unit that contains the given source file.
+  /// 
+  /// If no unit containing the given source file exists, returns `None`.
+  llvm::Optional<llvm::sys::TimePoint<>> timestampOfLatestUnitForFile(StringRef filePath);
 };
 
 } // anonymous namespace
@@ -627,6 +632,11 @@ bool IndexSystemImpl::foreachUnitTestSymbol(function_ref<bool(SymbolOccurrenceRe
   return SymIndex->foreachUnitTestSymbol(std::move(receiver));
 }
 
+llvm::Optional<llvm::sys::TimePoint<>> IndexSystemImpl::timestampOfLatestUnitForFile(StringRef filePath) {
+  auto canonFilePath = PathIndex->getCanonicalPath(filePath);
+  return SymIndex->timestampOfLatestUnitForFile(canonFilePath);
+}
+
 //===----------------------------------------------------------------------===//
 // IndexSystem
 //===----------------------------------------------------------------------===//
@@ -843,4 +853,8 @@ bool IndexSystem::foreachUnitTestSymbolReferencedByMainFiles(
 
 bool IndexSystem::foreachUnitTestSymbol(function_ref<bool(SymbolOccurrenceRef Occur)> receiver) {
   return IMPL->foreachUnitTestSymbol(std::move(receiver));
+}
+
+llvm::Optional<llvm::sys::TimePoint<>> IndexSystem::timestampOfLatestUnitForFile(StringRef filePath) {
+  return IMPL->timestampOfLatestUnitForFile(filePath);
 }


### PR DESCRIPTION
This allows us to check for out-of-date index entries in sourcekit-lsp.