### PR TITLE
[6.0] Make `Symbol` conform to `Hashable`

### DIFF
--- a/Sources/IndexStoreDB/Symbol.swift
+++ b/Sources/IndexStoreDB/Symbol.swift
@@ -52,7 +52,7 @@ public enum Language: Hashable {
   case swift
 }
 
-public struct Symbol: Equatable {
+public struct Symbol: Hashable {
 
   public var usr: String
   public var name: String


### PR DESCRIPTION
* **Explanation**: https://github.com/apple/sourcekit-lsp/pull/1166 creates a dictionary with `Symbol` as a key, which requires `Symbol` to conform to `Hashable`
* **Scope**: Adding `Hashable` conformance to `Symbol`
* **Risk**: Very low, just adding a protocol conformance
* **Testing**: Verified that `Symbol` can be used as a dictionary key with this change
* **Issue**: n/a
* **Reviewer**:  @bnbarham on https://github.com/apple/indexstore-db/pull/187