### PR TITLE
Make `indexstoredb_symbol_location_timestamp` and `indexstoredb_timestamp_of_latest_unit_for_file` return nanoseconds instead of seconds

### DIFF
--- a/Sources/IndexStoreDB/IndexStoreDB.swift
+++ b/Sources/IndexStoreDB/IndexStoreDB.swift
@@ -451,7 +451,7 @@ public final class IndexStoreDB {
   }
 
   /// Returns the latest modification date of a unit that contains the given source file.
-  /// 
+  ///
   /// If no unit containing the given source file exists, returns `nil`.
   public func dateOfLatestUnitFor(filePath: String) -> Date? {
     let timestamp = filePath.withCString { filePathCString in
@@ -460,7 +460,7 @@ public final class IndexStoreDB {
     if timestamp == 0 {
       return nil
     }
-    return Date(timeIntervalSince1970: timestamp)
+    return Date(timeIntervalSince1970: Double(timestamp) / 1_000_000_000)
   }
 }
 

--- a/Sources/IndexStoreDB/SymbolLocation.swift
+++ b/Sources/IndexStoreDB/SymbolLocation.swift
@@ -51,7 +51,7 @@ extension SymbolLocation: CustomStringConvertible {
 extension SymbolLocation {
   internal init(_ loc: indexstoredb_symbol_location_t) {
     path = String(cString: indexstoredb_symbol_location_path(loc))
-    timestamp = Date(timeIntervalSince1970: indexstoredb_symbol_location_timestamp(loc))
+    timestamp = Date(timeIntervalSince1970: Double(indexstoredb_symbol_location_timestamp(loc)) / 1_000_000_000)
     moduleName = String(cString: indexstoredb_symbol_location_module_name(loc))
     isSystem = indexstoredb_symbol_location_is_system(loc)
     line = Int(indexstoredb_symbol_location_line(loc))

--- a/include/CIndexStoreDB/CIndexStoreDB.h
+++ b/include/CIndexStoreDB/CIndexStoreDB.h
@@ -320,7 +320,7 @@ indexstoredb_index_related_symbol_occurrences_by_usr(
     _Nonnull indexstoredb_symbol_occurrence_receiver_t);
 
 /// Iterates over all the symbols contained in \p path
-/// 
+///
 /// The symbol passed to the receiver is only valid for the duration of the
 /// receiver call.
 INDEXSTOREDB_PUBLIC bool
@@ -375,10 +375,10 @@ INDEXSTOREDB_PUBLIC
 const char * _Nonnull
 indexstoredb_symbol_location_path(_Nonnull indexstoredb_symbol_location_t);
 
-/// Returns a Unix timestamp (seconds since 1/1/1970) at which the unit file that contains a symbol has last been 
+/// Returns a Unix timestamp (nanoseconds since 1/1/1970) at which the unit file that contains a symbol has last been
 /// modified.
 INDEXSTOREDB_PUBLIC
-double
+uint64_t
 indexstoredb_symbol_location_timestamp(_Nonnull indexstoredb_symbol_location_t loc);
 
 /// Returns the module name of the given symbol location.
@@ -577,10 +577,10 @@ indexstoredb_index_unit_tests(
   _Nonnull indexstoredb_symbol_occurrence_receiver_t receiver
 );
 
-/// Returns a Unix timestamp (seconds since 1/1/1970) of the latest unit that contains the given source file.
-/// 
+/// Returns a Unix timestamp (nanoseconds since 1/1/1970) of the latest unit that contains the given source file.
+///
 /// If no unit containing the given source file exists, returns 0.
-INDEXSTOREDB_PUBLIC double
+INDEXSTOREDB_PUBLIC uint64_t
 indexstoredb_timestamp_of_latest_unit_for_file(
   _Nonnull indexstoredb_index_t index,
   const char *_Nonnull fileName

--- a/lib/CIndexStoreDB/CIndexStoreDB.cpp
+++ b/lib/CIndexStoreDB/CIndexStoreDB.cpp
@@ -445,15 +445,14 @@ indexstoredb_symbol_location_path(indexstoredb_symbol_location_t loc) {
   return obj->getPath().getPathString().c_str();
 }
 
-double
+uint64_t
 indexstoredb_symbol_location_timestamp(indexstoredb_symbol_location_t loc) {
   auto obj = (SymbolLocation *)loc;
   // Up until C++20 the reference date of time_since_epoch is undefined but according to
   // https://en.cppreference.com/w/cpp/chrono/system_clock most implementations use Unix Time.
   // Since C++20, system_clock is defined to measure time since 1/1/1970.
   // We rely on `time_since_epoch` always returning the nanoseconds since 1/1/1970.
-  auto nanosecondsSinceEpoch = obj->getPath().getModificationTime().time_since_epoch().count();
-  return static_cast<double>(nanosecondsSinceEpoch) / 1000 / 1000 / 1000;
+  return obj->getPath().getModificationTime().time_since_epoch().count();
 }
 
 const char *
@@ -668,7 +667,7 @@ indexstoredb_index_unit_tests(
   });
 }
 
-INDEXSTOREDB_PUBLIC double
+INDEXSTOREDB_PUBLIC uint64_t
 indexstoredb_timestamp_of_latest_unit_for_file(
   _Nonnull indexstoredb_index_t index,
   const char *_Nonnull fileName
@@ -680,8 +679,7 @@ indexstoredb_timestamp_of_latest_unit_for_file(
     // https://en.cppreference.com/w/cpp/chrono/system_clock most implementations use Unix Time.
     // Since C++20, system_clock is defined to measure time since 1/1/1970.
     // We rely on `time_since_epoch` always returning the nanoseconds since 1/1/1970.
-    auto nanosecondsSinceEpoch = timePoint->time_since_epoch().count();
-    return static_cast<double>(nanosecondsSinceEpoch) / 1000 / 1000 / 1000;
+    return timePoint->time_since_epoch().count();
   }
   return 0;
 }


### PR DESCRIPTION
rdar://126581823