### PR TITLE
Fix issue that converted a unix timestamp to from nanoseconds to seconds twice

### DIFF
--- a/lib/CIndexStoreDB/CIndexStoreDB.cpp
+++ b/lib/CIndexStoreDB/CIndexStoreDB.cpp
@@ -679,8 +679,7 @@ indexstoredb_timestamp_of_latest_unit_for_file(
     // https://en.cppreference.com/w/cpp/chrono/system_clock most implementations use Unix Time.
     // Since C++20, system_clock is defined to measure time since 1/1/1970.
     // We rely on `time_since_epoch` always returning the nanoseconds since 1/1/1970.
-    auto nanosecondsSinceEpoch = timePoint->time_since_epoch().count();
-    return static_cast<double>(nanosecondsSinceEpoch) / 1000 / 1000 / 1000;
+    return timePoint->time_since_epoch().count();
   }
   return 0;
 }


### PR DESCRIPTION
An incorrect cherry-pick caused us to device the nanoseconds twice by 1.000.000.000, when we should only divide it once.

This makes the state of `release/6.0` match `main`.