### PR TITLE
Mark `SymbolProperty` and `SymbolRole` as `Sendable`

### DIFF
--- a/Sources/IndexStoreDB/SymbolProperty.swift
+++ b/Sources/IndexStoreDB/SymbolProperty.swift
@@ -13,7 +13,7 @@
 @_implementationOnly
 import CIndexStoreDB
 
-public struct SymbolProperty: OptionSet, Hashable {
+public struct SymbolProperty: OptionSet, Hashable, Sendable {
   public var rawValue: UInt64
 
   public static let generic: SymbolProperty = SymbolProperty(rawValue: INDEXSTOREDB_SYMBOL_PROPERTY_GENERIC)

--- a/Sources/IndexStoreDB/SymbolRole.swift
+++ b/Sources/IndexStoreDB/SymbolRole.swift
@@ -13,7 +13,7 @@
 @_implementationOnly
 import CIndexStoreDB
 
-public struct SymbolRole: OptionSet, Hashable {
+public struct SymbolRole: OptionSet, Hashable, Sendable {
 
   public var rawValue: UInt64
 


### PR DESCRIPTION
This allows us to build the `SourceKitLSP` module in Swift 6 mode.