### PR TITLE
Revert "Allow retrieval of the symbol provider kind for a source file"

### DIFF
--- a/Sources/IndexStoreDB/SymbolOccurrence.swift
+++ b/Sources/IndexStoreDB/SymbolOccurrence.swift
@@ -74,8 +74,7 @@ extension SymbolOccurrence {
       symbol: Symbol(indexstoredb_symbol_occurrence_symbol(value)),
       location: SymbolLocation(indexstoredb_symbol_occurrence_location(value)),
       roles: SymbolRole(rawValue: indexstoredb_symbol_occurrence_roles(value)),
-      // Force unwrap is OK because `indexstoredb_symbol_occurrence_symbol_provider_kind` never returns `INDEXSTOREDB_SYMBOL_PROVIDER_KIND_UNKNOWN`
-      symbolProvider: SymbolProviderKind(indexstoredb_symbol_occurrence_symbol_provider_kind(value))!,
+      symbolProvider: SymbolProviderKind(indexstoredb_symbol_occurrence_symbol_provider_kind(value)),
       relations: relations)
   }
 }

--- a/include/CIndexStoreDB/CIndexStoreDB.h
+++ b/include/CIndexStoreDB/CIndexStoreDB.h
@@ -498,9 +498,6 @@ indexstoredb_unit_info_main_file_path(_Nonnull indexstoredb_unit_info_t);
 INDEXSTOREDB_PUBLIC const char *_Nonnull
 indexstoredb_unit_info_unit_name(_Nonnull indexstoredb_unit_info_t);
 
-INDEXSTOREDB_PUBLIC indexstoredb_symbol_provider_kind_t
-indexstoredb_unit_info_symbol_provider_kind(_Nonnull indexstoredb_unit_info_t info);
-
 /// Iterates over the compilation units that contain \p path and return their units.
 ///
 /// This can be used to find information for units that include a given header.

--- a/include/IndexStoreDB/Index/StoreUnitInfo.h
+++ b/include/IndexStoreDB/Index/StoreUnitInfo.h
@@ -13,7 +13,6 @@
 #ifndef INDEXSTOREDB_INDEX_STOREUNITINFO_H
 #define INDEXSTOREDB_INDEX_STOREUNITINFO_H
 
-#include "IndexStoreDB/Core/Symbol.h"
 #include "IndexStoreDB/Support/Path.h"
 #include "llvm/Support/Chrono.h"
 #include <string>
@@ -27,18 +26,16 @@ struct StoreUnitInfo {
   std::string OutFileIdentifier;
   bool HasTestSymbols = false;
   llvm::sys::TimePoint<> ModTime;
-  Optional<SymbolProviderKind> SymProviderKind;
 
   StoreUnitInfo() = default;
   StoreUnitInfo(std::string unitName, CanonicalFilePath mainFilePath,
                 StringRef outFileIdentifier, bool hasTestSymbols,
-                llvm::sys::TimePoint<> modTime,
-                Optional<SymbolProviderKind> SymProviderKind)
+                llvm::sys::TimePoint<> modTime)
       : UnitName(unitName),
         MainFilePath(mainFilePath),
         OutFileIdentifier(outFileIdentifier),
         HasTestSymbols(hasTestSymbols),
-        ModTime(modTime), SymProviderKind(SymProviderKind) {}
+        ModTime(modTime) {}
 };
 
 } // namespace index

--- a/lib/CIndexStoreDB/CIndexStoreDB.cpp
+++ b/lib/CIndexStoreDB/CIndexStoreDB.cpp
@@ -589,20 +589,6 @@ indexstoredb_unit_info_unit_name(indexstoredb_unit_info_t info) {
   return obj->UnitName.c_str();
 }
 
-indexstoredb_symbol_provider_kind_t
-indexstoredb_unit_info_symbol_provider_kind(_Nonnull indexstoredb_unit_info_t info) {
-  auto obj = (const StoreUnitInfo *)info;
-  if (!obj->SymProviderKind) {
-    return INDEXSTOREDB_SYMBOL_PROVIDER_KIND_UNKNOWN;
-  }
-  switch (*obj->SymProviderKind) {
-  case IndexStoreDB::SymbolProviderKind::Clang:
-    return INDEXSTOREDB_SYMBOL_PROVIDER_KIND_CLANG;
-  case IndexStoreDB::SymbolProviderKind::Swift:
-    return INDEXSTOREDB_SYMBOL_PROVIDER_KIND_SWIFT;
-  }
-}
-
 bool
 indexstoredb_index_units_containing_file(
   indexstoredb_index_t index,

--- a/lib/Index/FilePathIndex.cpp
+++ b/lib/Index/FilePathIndex.cpp
@@ -166,7 +166,6 @@ bool FileIndexImpl::foreachMainUnitContainingFile(CanonicalFilePathRef filePath,
       currUnit.ModTime = unitInfo.ModTime;
       currUnit.MainFilePath = reader.getFullFilePathFromCode(unitInfo.MainFileCode);
       currUnit.OutFileIdentifier = reader.getUnitFileIdentifierFromCode(unitInfo.OutFileCode);
-      currUnit.SymProviderKind = unitInfo.SymProviderKind;
       return true;
     });
   }


### PR DESCRIPTION
This reverts commit a335a473dc2cd79edfb1f025b72f815f11df97a2.

The API is no longer needed.