### PR TITLE
[6.0] Expose the symbol provider of a SymbolOccurrence via the Swift API

### DIFF
--- a/Sources/ISDBTestSupport/TestLocation.swift
+++ b/Sources/ISDBTestSupport/TestLocation.swift
@@ -62,8 +62,8 @@ extension SymbolLocation {
 extension Symbol {
 
   /// Returns a SymbolOccurrence with the given location and roles.
-  public func at(_ location: TestLocation, moduleName: String = TestLocation.unknownModuleName, roles: SymbolRole) -> SymbolOccurrence {
-    return self.at(SymbolLocation(location, moduleName: moduleName), roles: roles)
+  public func at(_ location: TestLocation, moduleName: String = TestLocation.unknownModuleName, roles: SymbolRole, symbolProvider: SymbolProviderKind) -> SymbolOccurrence {
+    return self.at(SymbolLocation(location, moduleName: moduleName), symbolProvider: symbolProvider, roles: roles)
   }
 }
 

--- a/Sources/IndexStoreDB/IndexStoreDB.swift
+++ b/Sources/IndexStoreDB/IndexStoreDB.swift
@@ -39,6 +39,19 @@ public struct PathMapping {
 public enum SymbolProviderKind {
   case clang
   case swift
+
+  init?(_ cKind: indexstoredb_symbol_provider_kind_t) {
+    switch cKind {
+    case INDEXSTOREDB_SYMBOL_PROVIDER_KIND_SWIFT:
+      self = .swift
+    case INDEXSTOREDB_SYMBOL_PROVIDER_KIND_CLANG:
+      self = .clang
+    case INDEXSTOREDB_SYMBOL_PROVIDER_KIND_UNKNOWN:
+      return nil
+    default:
+      preconditionFailure("Unknown enum case in indexstoredb_symbol_provider_kind_t")
+    }
+  }
 }
 
 /// IndexStoreDB index.
@@ -289,16 +302,7 @@ public final class IndexStoreDB {
   public func symbolProvider(for sourceFilePath: String) -> SymbolProviderKind? {
     var result: SymbolProviderKind? = nil
     indexstoredb_index_units_containing_file(impl, sourceFilePath) { unit in
-      let providerKind: SymbolProviderKind? = switch indexstoredb_unit_info_symbol_provider_kind(unit) {
-      case INDEXSTOREDB_SYMBOL_PROVIDER_KIND_SWIFT:
-        .swift
-      case INDEXSTOREDB_SYMBOL_PROVIDER_KIND_CLANG:
-        .clang
-      case INDEXSTOREDB_SYMBOL_PROVIDER_KIND_UNKNOWN:
-        nil
-      default:
-        preconditionFailure("Unknown enum case in indexstoredb_symbol_provider_kind_t")
-      }
+      let providerKind = SymbolProviderKind(indexstoredb_unit_info_symbol_provider_kind(unit))
 
       let mainFilePath = String(cString: indexstoredb_unit_info_main_file_path(unit))
       if providerKind == .swift && mainFilePath != sourceFilePath {

--- a/Sources/IndexStoreDB/Symbol.swift
+++ b/Sources/IndexStoreDB/Symbol.swift
@@ -110,8 +110,8 @@ extension Symbol {
   }
 
   /// Returns a SymbolOccurrence with the given location and roles.
-  public func at(_ location: SymbolLocation, roles: SymbolRole) -> SymbolOccurrence {
-    return SymbolOccurrence(symbol: self, location: location, roles: roles)
+  public func at(_ location: SymbolLocation, symbolProvider: SymbolProviderKind, roles: SymbolRole) -> SymbolOccurrence {
+    return SymbolOccurrence(symbol: self, location: location, roles: roles, symbolProvider: symbolProvider)
   }
 }
 

--- a/Sources/IndexStoreDB/SymbolOccurrence.swift
+++ b/Sources/IndexStoreDB/SymbolOccurrence.swift
@@ -17,12 +17,14 @@ public struct SymbolOccurrence: Equatable {
   public var symbol: Symbol
   public var location: SymbolLocation
   public var roles: SymbolRole
+  public var symbolProvider: SymbolProviderKind
   public var relations: [SymbolRelation]
 
-  public init(symbol: Symbol, location: SymbolLocation, roles: SymbolRole, relations: [SymbolRelation] = []) {
+  public init(symbol: Symbol, location: SymbolLocation, roles: SymbolRole, symbolProvider: SymbolProviderKind, relations: [SymbolRelation] = []) {
     self.symbol = symbol
     self.location = location
     self.roles = roles
+    self.symbolProvider = symbolProvider
     self.relations = relations
   }
 }
@@ -72,6 +74,8 @@ extension SymbolOccurrence {
       symbol: Symbol(indexstoredb_symbol_occurrence_symbol(value)),
       location: SymbolLocation(indexstoredb_symbol_occurrence_location(value)),
       roles: SymbolRole(rawValue: indexstoredb_symbol_occurrence_roles(value)),
+      // Force unwrap is OK because `indexstoredb_symbol_occurrence_symbol_provider_kind` never returns `INDEXSTOREDB_SYMBOL_PROVIDER_KIND_UNKNOWN`
+      symbolProvider: SymbolProviderKind(indexstoredb_symbol_occurrence_symbol_provider_kind(value))!,
       relations: relations)
   }
 }

--- a/Tests/IndexStoreDBTests/IndexTests.swift
+++ b/Tests/IndexStoreDBTests/IndexTests.swift
@@ -48,12 +48,14 @@ final class IndexTests: XCTestCase {
       symbol: csym,
       location: SymbolLocation(ws.testLoc("c"), moduleName: "main"),
       roles: [.definition, .canonical],
+      symbolProvider: .clang,
       relations: [])
 
     let ccall = SymbolOccurrence(
       symbol: csym,
       location: SymbolLocation(ws.testLoc("c:call")),
       roles: [.reference, .call, .calledBy, .containedBy],
+      symbolProvider: .clang,
       relations: [
         .init(symbol: asym, roles: [.calledBy, .containedBy])
     ])
@@ -95,6 +97,7 @@ final class IndexTests: XCTestCase {
         symbol: Symbol(usr: "s:4main1byyF", name: "b()", kind: .function, language: .swift),
         location: SymbolLocation(ws.testLoc("b:call")),
         roles: [.reference, .call, .calledBy, .containedBy],
+        symbolProvider: .swift,
         relations: [
           .init(symbol: asym, roles: [.calledBy, .containedBy])
       ])
@@ -111,35 +114,35 @@ final class IndexTests: XCTestCase {
     let cdecl = Symbol(usr: "c:objc(cs)C", name: "C", kind: .class, language: .objc)
     let cdeclOccs = index.occurrences(ofUSR: cdecl.usr, roles: .all)
     checkOccurrences(cdeclOccs, expected: [
-      cdecl.at(ws.testLoc("C:decl"), roles: [.declaration, .canonical]),
-      cdecl.at(ws.testLoc("C:def"), roles: .definition),
-      cdecl.with(language: .swift).at(ws.testLoc("C:ref:swift"), roles: .reference),
-      cdecl.at(ws.testLoc("C:ref:e.mm"), roles: .reference),
+      cdecl.at(ws.testLoc("C:decl"), roles: [.declaration, .canonical], symbolProvider: .clang),
+      cdecl.at(ws.testLoc("C:def"), roles: .definition, symbolProvider: .clang),
+      cdecl.with(language: .swift).at(ws.testLoc("C:ref:swift"), roles: .reference, symbolProvider: .clang),
+      cdecl.at(ws.testLoc("C:ref:e.mm"), roles: .reference, symbolProvider: .clang),
     ])
 
     let cmethod = Symbol(usr: "c:objc(cs)C(im)method", name: "method", kind: .instanceMethod, language: .objc)
     let cmethodOccs = index.occurrences(ofUSR: cmethod.usr, roles: .all)
     checkOccurrences(cmethodOccs, expected: [
-      cmethod.with(name: "method()", language: .swift).at(ws.testLoc("C.method:call:swift"), roles: [.call, .dynamic]),
-      cmethod.at(ws.testLoc("C.method:decl"), roles: .declaration),
-      cmethod.at(ws.testLoc("C.method:def"), roles: .definition),
-      cmethod.at(ws.testLoc("C.method:call:e.mm"), roles: [.call, .dynamic]),
+      cmethod.with(name: "method()", language: .swift).at(ws.testLoc("C.method:call:swift"), roles: [.call, .dynamic], symbolProvider: .swift),
+      cmethod.at(ws.testLoc("C.method:decl"), roles: .declaration, symbolProvider: .clang),
+      cmethod.at(ws.testLoc("C.method:def"), roles: .definition, symbolProvider: .clang),
+      cmethod.at(ws.testLoc("C.method:call:e.mm"), roles: [.call, .dynamic], symbolProvider: .clang),
     ])
   #endif
 
     let ddecl = Symbol(usr: "c:@S@D", name: "D", kind: .class, language: .cxx)
     let dOccs = index.occurrences(ofUSR: ddecl.usr, roles: .all)
     checkOccurrences(dOccs, expected: [
-      ddecl.at(ws.testLoc("D:def"), roles: .definition),
-      ddecl.at(ws.testLoc("D:ref"), roles: .reference),
-      ddecl.at(ws.testLoc("D:ref:e.mm"), roles: .reference),
+      ddecl.at(ws.testLoc("D:def"), roles: .definition, symbolProvider: .clang),
+      ddecl.at(ws.testLoc("D:ref"), roles: .reference, symbolProvider: .clang),
+      ddecl.at(ws.testLoc("D:ref:e.mm"), roles: .reference, symbolProvider: .clang),
     ])
 
     let bhdecl = Symbol(usr: "c:@F@bridgingHeader", name: "bridgingHeader", kind: .function, language: .c)
     let bridgingHeaderOccs = index.occurrences(ofUSR: bhdecl.usr, roles: .all)
     checkOccurrences(bridgingHeaderOccs, expected: [
-      bhdecl.at(ws.testLoc("bridgingHeader:decl"), roles: .declaration),
-      bhdecl.with(name: "bridgingHeader()", language: .swift).at(ws.testLoc("bridgingHeader:call"), roles: .call),
+      bhdecl.at(ws.testLoc("bridgingHeader:decl"), roles: .declaration, symbolProvider: .clang),
+      bhdecl.with(name: "bridgingHeader()", language: .swift).at(ws.testLoc("bridgingHeader:call"), roles: .call, symbolProvider: .clang),
     ])
   }
 
@@ -157,25 +160,25 @@ final class IndexTests: XCTestCase {
     let cdecl = Symbol(usr: "c:objc(cs)C", name: "C", kind: .class, language: .objc)
     let cdeclOccs = index.occurrences(ofUSR: cdecl.usr, roles: .all)
     checkOccurrences(cdeclOccs, expected: [
-      cdecl.at(ws.testLoc("C:decl"), roles: [.declaration, .canonical]),
-      cdecl.at(ws.testLoc("C:def"), roles: .definition),
-      cdecl.with(language: .swift).at(ws.testLoc("C:ref:swift"), roles: .reference),
+      cdecl.at(ws.testLoc("C:decl"), roles: [.declaration, .canonical], symbolProvider: .clang),
+      cdecl.at(ws.testLoc("C:def"), roles: .definition, symbolProvider: .clang),
+      cdecl.with(language: .swift).at(ws.testLoc("C:ref:swift"), roles: .reference, symbolProvider: .swift),
     ])
 
     let cmethod = Symbol(usr: "c:objc(cs)C(im)method", name: "method", kind: .instanceMethod, language: .objc)
     let cmethodOccs = index.occurrences(ofUSR: cmethod.usr, roles: .all)
     checkOccurrences(cmethodOccs, expected: [
-      cmethod.with(name: "method()", language: .swift).at(ws.testLoc("C.method:call:swift"), roles: [.call, .dynamic]),
-      cmethod.at(ws.testLoc("C.method:decl"), roles: .declaration),
-      cmethod.at(ws.testLoc("C.method:def"), roles: .definition),
+      cmethod.with(name: "method()", language: .swift).at(ws.testLoc("C.method:call:swift"), roles: [.call, .dynamic], symbolProvider: .clang),
+      cmethod.at(ws.testLoc("C.method:decl"), roles: .declaration, symbolProvider: .clang),
+      cmethod.at(ws.testLoc("C.method:def"), roles: .definition, symbolProvider: .clang),
     ])
   #endif
 
     let bhdecl = Symbol(usr: "c:@F@bridgingHeader", name: "bridgingHeader", kind: .function, language: .c)
     let bridgingHeaderOccs = index.occurrences(ofUSR: bhdecl.usr, roles: .all)
     checkOccurrences(bridgingHeaderOccs, expected: [
-      bhdecl.at(ws.testLoc("bridgingHeader:decl"), roles: .declaration),
-      bhdecl.with(name: "bridgingHeader()", language: .swift).at(ws.testLoc("bridgingHeader:call"), roles: .call),
+      bhdecl.at(ws.testLoc("bridgingHeader:decl"), roles: .declaration, symbolProvider: .clang),
+      bhdecl.with(name: "bridgingHeader()", language: .swift).at(ws.testLoc("bridgingHeader:call"), roles: .call, symbolProvider: .swift),
     ])
   }
 
@@ -208,21 +211,21 @@ final class IndexTests: XCTestCase {
     let bhdecl = Symbol(usr: "c:@F@bridgingHeader", name: "bridgingHeader", kind: .function, language: .c)
     let bridgingHeaderOccs = index.occurrences(ofUSR: bhdecl.usr, roles: .all)
     checkOccurrences(bridgingHeaderOccs, expected: [
-      bhdecl.at(ws.testLoc("bridgingHeader:decl"), roles: .declaration),
-      bhdecl.with(name: "bridgingHeader()", language: .swift).at(ws.testLoc("bridgingHeader:call"), roles: .call),
+      bhdecl.at(ws.testLoc("bridgingHeader:decl"), roles: .declaration, symbolProvider: .clang),
+      bhdecl.with(name: "bridgingHeader()", language: .swift).at(ws.testLoc("bridgingHeader:call"), roles: .call, symbolProvider: .swift),
     ])
   #if os(macOS)
     checkOccurrences(getOccs(), expected: [
-      cdecl.at(ws.testLoc("C:decl"), roles: [.declaration, .canonical]),
-      cdecl.at(ws.testLoc("C:def"), roles: .definition),
-      cdecl.with(language: .swift).at(ws.testLoc("C:ref:swift"), roles: .reference),
+      cdecl.at(ws.testLoc("C:decl"), roles: [.declaration, .canonical], symbolProvider: .clang),
+      cdecl.at(ws.testLoc("C:def"), roles: .definition, symbolProvider: .clang),
+      cdecl.with(language: .swift).at(ws.testLoc("C:ref:swift"), roles: .reference, symbolProvider: .swift),
     ])
 
     let outUnitASwift = try XCTUnwrap(indexOutputPaths.first{ $0.hasSuffix("-a.swift.o") })
     index.removeUnitOutFilePaths([outUnitASwift], waitForProcessing: true)
     checkOccurrences(getOccs(), expected: [
-      cdecl.at(ws.testLoc("C:decl"), roles: [.declaration, .canonical]),
-      cdecl.at(ws.testLoc("C:def"), roles: .definition),
+      cdecl.at(ws.testLoc("C:decl"), roles: [.declaration, .canonical], symbolProvider: .clang),
+      cdecl.at(ws.testLoc("C:def"), roles: .definition, symbolProvider: .clang),
     ])
   #endif
   }
@@ -256,21 +259,21 @@ final class IndexTests: XCTestCase {
     let bhdecl = Symbol(usr: "c:@F@bridgingHeader", name: "bridgingHeader", kind: .function, language: .c)
     let bridgingHeaderOccs = index.occurrences(ofUSR: bhdecl.usr, roles: .all)
     checkOccurrences(bridgingHeaderOccs, expected: [
-      bhdecl.at(ws.testLoc("bridgingHeader:decl"), roles: .declaration),
-      bhdecl.with(name: "bridgingHeader()", language: .swift).at(ws.testLoc("bridgingHeader:call"), roles: .call),
+      bhdecl.at(ws.testLoc("bridgingHeader:decl"), roles: .declaration, symbolProvider: .clang),
+      bhdecl.with(name: "bridgingHeader()", language: .swift).at(ws.testLoc("bridgingHeader:call"), roles: .call, symbolProvider: .clang),
     ])
   #if os(macOS)
     checkOccurrences(getOccs(), expected: [
-      cdecl.at(ws.testLoc("C:decl"), roles: [.declaration, .canonical]),
-      cdecl.at(ws.testLoc("C:def"), roles: .definition),
-      cdecl.with(language: .swift).at(ws.testLoc("C:ref:swift"), roles: .reference),
+      cdecl.at(ws.testLoc("C:decl"), roles: [.declaration, .canonical], symbolProvider: .clang),
+      cdecl.at(ws.testLoc("C:def"), roles: .definition, symbolProvider: .clang),
+      cdecl.with(language: .swift).at(ws.testLoc("C:ref:swift"), roles: .reference, symbolProvider: .swift),
     ])
 
     let outUnitASwift = try XCTUnwrap(indexOutputPaths.first{ $0.hasSuffix("-a.swift.o") })
     index.removeUnitOutFilePaths([outUnitASwift], waitForProcessing: true)
     checkOccurrences(getOccs(), expected: [
-      cdecl.at(ws.testLoc("C:decl"), roles: [.declaration, .canonical]),
-      cdecl.at(ws.testLoc("C:def"), roles: .definition),
+      cdecl.at(ws.testLoc("C:decl"), roles: [.declaration, .canonical], symbolProvider: .clang),
+      cdecl.at(ws.testLoc("C:def"), roles: .definition, symbolProvider: .clang),
     ])
   #endif
   }
@@ -281,9 +284,9 @@ final class IndexTests: XCTestCase {
 
     let aaa = Symbol(usr: "s:1A3aaayyF", name: "aaa()", kind: .function, language: .swift)
     checkOccurrences(ws.index.occurrences(ofUSR: aaa.usr, roles: .all), expected: [
-      aaa.at(ws.testLoc("aaa:def"), moduleName: "A", roles: .definition),
-      aaa.at(ws.testLoc("aaa:call"), moduleName: "B", roles: .call),
-      aaa.at(ws.testLoc("aaa:call:c"), moduleName: "C", roles: .call),
+      aaa.at(ws.testLoc("aaa:def"), moduleName: "A", roles: .definition, symbolProvider: .swift),
+      aaa.at(ws.testLoc("aaa:call"), moduleName: "B", roles: .call, symbolProvider: .swift),
+      aaa.at(ws.testLoc("aaa:call:c"), moduleName: "C", roles: .call, symbolProvider: .swift),
     ])
   }
 
@@ -295,8 +298,8 @@ final class IndexTests: XCTestCase {
     let roles: SymbolRole = [.reference, .definition, .declaration]
 
     checkOccurrences(ws.index.occurrences(ofUSR: cdecl.usr, roles: .all), expected: [
-      cdecl.at(ws.testLoc("c"), roles: .definition),
-      cdecl.at(ws.testLoc("c:call"), roles: .call),
+      cdecl.at(ws.testLoc("c"), roles: .definition, symbolProvider: .clang),
+      cdecl.at(ws.testLoc("c:call"), roles: .call, symbolProvider: .clang),
     ])
 
     try ws.edit(rebuild: true) { editor, files in
@@ -312,9 +315,9 @@ final class IndexTests: XCTestCase {
     }
 
     checkOccurrences(ws.index.occurrences(ofUSR: cdecl.usr, roles: .all), expected: [
-      cdecl.at(ws.testLoc("c"), roles: .definition),
-      cdecl.at(ws.testLoc("c:call"), roles: .call),
-      cdecl.at(ws.testLoc("c:anotherOne"), roles: .call),
+      cdecl.at(ws.testLoc("c"), roles: .definition, symbolProvider: .clang),
+      cdecl.at(ws.testLoc("c:call"), roles: .call, symbolProvider: .clang),
+      cdecl.at(ws.testLoc("c:anotherOne"), roles: .call, symbolProvider: .clang),
     ])
 
     XCTAssertNotEqual(ws.testLoc("c").url, ws.testLoc("a:def").url)
@@ -331,9 +334,9 @@ final class IndexTests: XCTestCase {
 
     let newDecl = cdecl.with(usr: "s:4main1cSiyF")
     checkOccurrences(ws.index.occurrences(ofUSR: newDecl.usr, roles: .all), expected: [
-      newDecl.at(ws.testLoc("c"), roles: .definition),
-      newDecl.at(ws.testLoc("c:call"), roles: .call),
-      newDecl.at(ws.testLoc("c:anotherOne"), roles: .call),
+      newDecl.at(ws.testLoc("c"), roles: .definition, symbolProvider: .clang),
+      newDecl.at(ws.testLoc("c:call"), roles: .call, symbolProvider: .clang),
+      newDecl.at(ws.testLoc("c:anotherOne"), roles: .call, symbolProvider: .clang),
     ])
   }
 
@@ -355,11 +358,11 @@ final class IndexTests: XCTestCase {
       SymbolOccurrence(
        symbol: csym,
         location: SymbolLocation(ws.testLoc("c")),
-       roles: [.definition, .canonical]),
+       roles: [.definition, .canonical], symbolProvider: .clang),
       SymbolOccurrence(
         symbol: csym,
         location: SymbolLocation(ws.testLoc("c:call")),
-        roles: [.reference, .call, .calledBy, .containedBy]),
+        roles: [.reference, .call, .calledBy, .containedBy], symbolProvider: .clang),
     ])
   }
 
@@ -514,20 +517,20 @@ final class IndexTests: XCTestCase {
       IndexStoreDB.UnitIncludeEntry(sourcePath: main1, targetPath: uniq1, line: ws.testLoc("include_main1_uniq1").line),
     ])
   }
-    
+
   func testFilesIncludes() throws {
     guard let ws = try staticTibsTestWorkspace(name: "MainFiles") else { return }
     try ws.buildAndIndex()
     let index = ws.index
-        
+
     let main1 = ws.testLoc("main1").url.path
     let main2 = ws.testLoc("main2").url.path
     let uniq1 = ws.testLoc("uniq1").url.path
     let shared = ws.testLoc("shared").url.path
-        
+
     let includedFiles = index.filesIncludedByFile(path: main1).sorted()
     XCTAssertEqual(includedFiles, [shared, uniq1])
-    
+
     let includingFiles = index.filesIncludingFile(path: shared).sorted()
     XCTAssertEqual(includingFiles, [main1, main2])
   }
@@ -556,24 +559,24 @@ final class IndexTests: XCTestCase {
     let indexOutputPaths = ws.builder.indexOutputPaths.map{$0.path}
     index.addUnitOutFilePaths(indexOutputPaths, waitForProcessing: true)
     checkOccurrences(getOccs(), expected: [
-      ddecl.at(ws.testLoc("D:def"), roles: .definition),
-      ddecl.at(ws.testLoc("D:ref"), roles: .reference),
-      ddecl.at(ws.testLoc("D:ref:e.mm"), roles: .reference),
+      ddecl.at(ws.testLoc("D:def"), roles: .definition, symbolProvider: .clang),
+      ddecl.at(ws.testLoc("D:ref"), roles: .reference, symbolProvider: .clang),
+      ddecl.at(ws.testLoc("D:ref:e.mm"), roles: .reference, symbolProvider: .clang),
     ])
 
     let outUnitEMM = try XCTUnwrap(indexOutputPaths.first{ $0.hasSuffix("-e.mm.o") })
     index.removeUnitOutFilePaths([outUnitEMM], waitForProcessing: true)
     checkOccurrences(getOccs(), expected: [
-      ddecl.at(ws.testLoc("D:def"), roles: .definition),
-      ddecl.at(ws.testLoc("D:ref"), roles: .reference),
+      ddecl.at(ws.testLoc("D:def"), roles: .definition, symbolProvider: .clang),
+      ddecl.at(ws.testLoc("D:ref"), roles: .reference, symbolProvider: .clang),
     ])
 
     // The bridging header is referenced as a PCH unit dependency, make sure we can see the data.
     let bhdecl = Symbol(usr: "c:@F@bridgingHeader", name: "bridgingHeader", kind: .function, language: .c)
     let bridgingHeaderOccs = index.occurrences(ofUSR: bhdecl.usr, roles: .all)
     checkOccurrences(bridgingHeaderOccs, expected: [
-      bhdecl.at(ws.testLoc("bridgingHeader:decl"), roles: .declaration),
-      bhdecl.with(name: "bridgingHeader()", language: .swift).at(ws.testLoc("bridgingHeader:call"), roles: .call),
+      bhdecl.at(ws.testLoc("bridgingHeader:decl"), roles: .declaration, symbolProvider: .clang),
+      bhdecl.with(name: "bridgingHeader()", language: .swift).at(ws.testLoc("bridgingHeader:call"), roles: .call, symbolProvider: .swift),
     ])
   }
 
@@ -637,25 +640,25 @@ final class IndexTests: XCTestCase {
     let asyncFuncSym = Symbol(usr: "s:4main9asyncFuncyyYaF", name: "asyncFunc()", kind: .function, properties: .swiftAsync, language: .swift)
     let asyncFuncOccs = index.occurrences(ofUSR: asyncFuncSym.usr, roles: .definition)
     checkOccurrences(asyncFuncOccs, expected: [
-      asyncFuncSym.at(ws.testLoc("asyncFunc:def"), roles: .definition)
+      asyncFuncSym.at(ws.testLoc("asyncFunc:def"), roles: .definition, symbolProvider: .swift)
     ])
 
     let asyncMethSym = Symbol(usr: "s:4main8MyStructV11asyncMethodyyYaF", name: "asyncMethod()", kind: .instanceMethod, properties: .swiftAsync, language: .swift)
     let asyncMethOccs = index.occurrences(ofUSR: asyncMethSym.usr, roles: .definition)
     checkOccurrences(asyncMethOccs, expected: [
-      asyncMethSym.at(ws.testLoc("asyncMethod:def"), roles: .definition)
+      asyncMethSym.at(ws.testLoc("asyncMethod:def"), roles: .definition, symbolProvider: .swift)
     ])
 
     let testMeSym = Symbol(usr: "s:4main10MyTestCaseC6testMeyyF", name: "testMe()", kind: .instanceMethod, properties: .unitTest, language: .swift)
     let testMeOccs = index.occurrences(ofUSR: testMeSym.usr, roles: .definition)
     checkOccurrences(testMeOccs, expected: [
-      testMeSym.at(ws.testLoc("testMe:def"), roles: .definition)
+      testMeSym.at(ws.testLoc("testMe:def"), roles: .definition, symbolProvider: .swift)
     ])
 
     let testMeAsyncSym = Symbol(usr: "s:4main10MyTestCaseC11testMeAsyncyyYaF", name: "testMeAsync()", kind: .instanceMethod, properties: [.unitTest, .swiftAsync], language: .swift)
     let testMeAsyncOccs = index.occurrences(ofUSR: testMeAsyncSym.usr, roles: .definition)
     checkOccurrences(testMeAsyncOccs, expected: [
-      testMeAsyncSym.at(ws.testLoc("testMeAsync:def"), roles: .definition)
+      testMeAsyncSym.at(ws.testLoc("testMeAsync:def"), roles: .definition, symbolProvider: .swift)
     ])
   }
 
@@ -668,8 +671,8 @@ final class IndexTests: XCTestCase {
     let largeType = Symbol(usr: "c:@CT@LargeType", name: "LargeType", kind: .concept, language: .c)
     let largeTypeOccs = ws.index.occurrences(ofUSR: largeType.usr, roles: .all)
     checkOccurrences(largeTypeOccs, expected: [
-      largeType.at(ws.testLoc("LargeType:def"), roles: .definition),
-      largeType.at(ws.testLoc("LargeType:ref"), roles: .reference),
+      largeType.at(ws.testLoc("LargeType:def"), roles: .definition, symbolProvider: .swift),
+      largeType.at(ws.testLoc("LargeType:ref"), roles: .reference, symbolProvider: .swift),
     ])
   }
 }

--- a/include/CIndexStoreDB/CIndexStoreDB.h
+++ b/include/CIndexStoreDB/CIndexStoreDB.h
@@ -481,6 +481,9 @@ INDEXSTOREDB_PUBLIC bool
 indexstoredb_symbol_occurrence_relations(_Nonnull indexstoredb_symbol_occurrence_t,
                                          bool(^ _Nonnull applier)(indexstoredb_symbol_relation_t _Nonnull ));
 
+INDEXSTOREDB_PUBLIC indexstoredb_symbol_provider_kind_t
+indexstoredb_symbol_occurrence_symbol_provider_kind(indexstoredb_symbol_occurrence_t occur);
+
 /// Returns the kind of the given symbol.
 INDEXSTOREDB_PUBLIC indexstoredb_symbol_kind_t
 indexstoredb_symbol_kind(_Nonnull indexstoredb_symbol_t);

--- a/lib/CIndexStoreDB/CIndexStoreDB.cpp
+++ b/lib/CIndexStoreDB/CIndexStoreDB.cpp
@@ -427,6 +427,18 @@ indexstoredb_symbol_occurrence_relations(indexstoredb_symbol_occurrence_t occurr
   return true;
 }
 
+indexstoredb_symbol_provider_kind_t
+indexstoredb_symbol_occurrence_symbol_provider_kind(indexstoredb_symbol_occurrence_t occur) {
+  auto value = (SymbolOccurrence *)occur;
+  SymbolProviderKind symbolProvider = value->getSymbolProviderKind();
+  switch (value->getSymbolProviderKind()) {
+  case IndexStoreDB::SymbolProviderKind::Clang:
+    return INDEXSTOREDB_SYMBOL_PROVIDER_KIND_CLANG;
+  case IndexStoreDB::SymbolProviderKind::Swift:
+    return INDEXSTOREDB_SYMBOL_PROVIDER_KIND_SWIFT;
+  }
+}
+
 uint64_t
 indexstoredb_symbol_occurrence_roles(indexstoredb_symbol_occurrence_t occur) {
   auto value = (SymbolOccurrence *)occur;


### PR DESCRIPTION
- **Explanation**: Adds a new API to get the symbol provider of a `SymbolOccurrence `
- **Scope**: Adds new API
- **Risk**: Low, purely additive
- **Testing**: Tested in SourceKit-LSP
- **Issue**: n/a
- **Reviewer**:   @bnbarham on https://github.com/apple/indexstore-db/pull/200
