### PR TITLE
Update README.md with a modern example of using `indexstore-db`

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,8 @@ $ swift build -Xcxx -I<path_to_swift_toolchain>/usr/lib/swift -Xcxx -I<path_to_s
 ## Some Example Users
 
 [**Pecker**](https://github.com/woshiccm/Pecker): a tool to detect unused code based on [SwiftSyntax](https://github.com/swiftlang/swift-syntax.git) and [IndexStoreDB](https://github.com/swiftlang/indexstore-db.git).
-
+[**xcresultowners**](https://github.com/sdidla/xcresultowners): a tool and library to locate failing tests and their respective owners. Uses [github.com's](https://github.com)[`CODEOWNERS`](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners) for ownership look-ups and [IndexStoreDB](https://github.com/swiftlang/indexstore-db.git) for test case look-ups.
+  
 ## Contributing to Swift
 
 Contributions to indexstore-db are welcomed and encouraged! Please see the


### PR DESCRIPTION
Includes a modern, usable, fully-documented and tested project that uses `indexstore-db` to solve a real-world problem into the "Examples" section of the `README` of the project.

- https://github.com/sdidla/xcresultowners

Excerpt from the `README.md` of my project:
> This project supplements the test results summary produced by [`xcresulttool`](https://keith.github.io/xcode-man-pages/xcresulttool.1.html) with code ownership defined in GitHub's [`CODEOWNERS`](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners) file
 