### PR TITLE
Remove superfluous `borrow` clauses

### DIFF
--- a/Sources/IndexStore/IndexStoreOccurrence.swift
+++ b/Sources/IndexStore/IndexStoreOccurrence.swift
@@ -23,7 +23,7 @@ public struct IndexStoreOccurrence: ~Escapable, Sendable {
   @usableFromInline nonisolated(unsafe) let occurrence: indexstore_occurrence_t
   @usableFromInline let library: IndexStoreLibrary
 
-  @usableFromInline @_lifetime(borrow occurrence, borrow library)
+  @usableFromInline @_lifetime(borrow library)
   init(occurrence: indexstore_occurrence_t, library: borrowing IndexStoreLibrary) {
     self.occurrence = occurrence
     self.library = library

--- a/Sources/IndexStore/IndexStoreSymbol.swift
+++ b/Sources/IndexStore/IndexStoreSymbol.swift
@@ -128,7 +128,7 @@ public struct IndexStoreSymbol: ~Escapable, Sendable {
   @usableFromInline nonisolated(unsafe) let symbol: indexstore_symbol_t
   @usableFromInline let library: IndexStoreLibrary
 
-  @usableFromInline @_lifetime(borrow symbol, borrow library)
+  @usableFromInline @_lifetime(borrow library)
   init(symbol: indexstore_symbol_t, library: borrowing IndexStoreLibrary) {
     self.symbol = symbol
     self.library = library

--- a/Sources/IndexStore/IndexStoreSymbolRelation.swift
+++ b/Sources/IndexStore/IndexStoreSymbolRelation.swift
@@ -17,7 +17,7 @@ public struct IndexStoreSymbolRelation: ~Escapable, Sendable {
   @usableFromInline nonisolated(unsafe) let relation: indexstore_symbol_relation_t
   @usableFromInline let library: IndexStoreLibrary
 
-  @usableFromInline @_lifetime(borrow relation, borrow library)
+  @usableFromInline @_lifetime(borrow library)
   init(relation: indexstore_symbol_relation_t, library: borrowing IndexStoreLibrary) {
     self.relation = relation
     self.library = library

--- a/Sources/IndexStore/IndexStoreUnitDependency.swift
+++ b/Sources/IndexStore/IndexStoreUnitDependency.swift
@@ -34,7 +34,7 @@ public struct IndexStoreUnitDependency: ~Escapable, Sendable {
   @usableFromInline nonisolated(unsafe) let dependency: indexstore_unit_dependency_t
   @usableFromInline let library: IndexStoreLibrary
 
-  @usableFromInline @_lifetime(borrow dependency, borrow library)
+  @usableFromInline @_lifetime(borrow library)
   init(dependency: indexstore_unit_dependency_t, library: borrowing IndexStoreLibrary) {
     self.dependency = dependency
     self.library = library

--- a/Sources/IndexStore/IndexStoreUnitInclude.swift
+++ b/Sources/IndexStore/IndexStoreUnitInclude.swift
@@ -17,7 +17,7 @@ public struct IndexStoreUnitInclude: ~Escapable, Sendable {
   @usableFromInline nonisolated(unsafe) let include: indexstore_unit_include_t
   @usableFromInline let library: IndexStoreLibrary
 
-  @usableFromInline @_lifetime(borrow include, borrow library)
+  @usableFromInline @_lifetime(borrow library)
   init(include: indexstore_unit_include_t, library: borrowing IndexStoreLibrary) {
     self.include = include
     self.library = library


### PR DESCRIPTION
Turns out that these have no effect.
