### PR TITLE
Create an executable to dump index or record files

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -7,6 +7,16 @@ func hasEnvironmentVariable(_ name: String) -> Bool {
   return ProcessInfo.processInfo.environment[name] != nil
 }
 
+/// Settings to apply to targets building in Swift 6 mode.
+let swift6Settings: [SwiftSetting] = [
+  .swiftLanguageMode(.v6),
+  .enableUpcomingFeature("ExistentialAny"),
+  .enableUpcomingFeature("InternalImportsByDefault"),
+  .enableUpcomingFeature("MemberImportVisibility"),
+  .enableUpcomingFeature("InferIsolatedConformances"),
+  .enableUpcomingFeature("NonisolatedNonsendingByDefault"),
+]
+
 /// Assume that all the package dependencies are checked out next to indexstore-db and use that instead of fetching a
 /// remote dependency.
 var useLocalDependencies: Bool { hasEnvironmentVariable("SWIFTCI_USE_LOCAL_DEPS") }
@@ -14,11 +24,13 @@ var useLocalDependencies: Bool { hasEnvironmentVariable("SWIFTCI_USE_LOCAL_DEPS"
 var dependencies: [Package.Dependency] {
   if useLocalDependencies {
     return [
-      .package(path: "../swift-lmdb")
+      .package(path: "../swift-lmdb"),
+      .package(path: "../swift-argument-parser"),
     ]
   } else {
     return [
-      .package(url: "https://github.com/swiftlang/swift-lmdb.git", branch: "main")
+      .package(url: "https://github.com/swiftlang/swift-lmdb.git", branch: "main"),
+      .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.5.1"),
     ]
   }
 }
@@ -47,6 +59,10 @@ let package = Package(
       name: "IndexStore",
       targets: ["IndexStore"]
     ),
+    .executable(
+      name: "index-dump",
+      targets: ["index-dump"]
+    ),
   ],
   dependencies: dependencies,
   targets: [
@@ -56,15 +72,7 @@ let package = Package(
       name: "IndexStore",
       dependencies: ["IndexStoreCAPI"],
       exclude: ["Index Store.md", "README.md"],
-      swiftSettings: [
-        .enableUpcomingFeature("ExistentialAny"),
-        .enableUpcomingFeature("InternalImportsByDefault"),
-        .enableUpcomingFeature("MemberImportVisibility"),
-        .enableUpcomingFeature("InferIsolatedConformances"),
-        .enableUpcomingFeature("NonisolatedNonsendingByDefault"),
-        .enableExperimentalFeature("Lifetimes"),
-        .swiftLanguageMode(.v6),
-      ]
+      swiftSettings: swift6Settings + [.enableExperimentalFeature("Lifetimes")]
     ),
 
     .testTarget(
@@ -198,6 +206,16 @@ let package = Package(
         "Windows/Threading.inc",
         "Windows/Watchdog.inc",
       ]
+    ),
+
+    // Executable to dump index and record files
+    .executableTarget(
+      name: "index-dump",
+      dependencies: [
+        "IndexStore",
+        .product(name: "ArgumentParser", package: "swift-argument-parser"),
+      ],
+      swiftSettings: swift6Settings
     ),
   ],
   swiftLanguageModes: [.v5],

--- a/Sources/ISDBTibs/Process.swift
+++ b/Sources/ISDBTibs/Process.swift
@@ -22,30 +22,23 @@ extension Process {
   /// Runs a subprocess and returns its output as a String if it has a zero exit.
   package static func tibs_checkNonZeroExit(
     arguments: [String],
-    environment: [String: String]? = nil
+    environment: [String: String]? = nil,
+    workingDirectory: URL? = nil
   ) throws -> String {
     let p = Process()
     let out = Pipe()
     let err = Pipe()
 
-    if #available(macOS 10.13, *) {
-      p.executableURL = URL(fileURLWithPath: arguments[0], isDirectory: false)
-    } else {
-      p.launchPath = arguments[0]
-    }
-
+    p.executableURL = URL(fileURLWithPath: arguments[0], isDirectory: false)
     p.arguments = Array(arguments[1...])
     if let environment = environment {
       p.environment = environment
     }
     p.standardOutput = out
     p.standardError = err
+    p.currentDirectoryURL = workingDirectory
 
-    if #available(macOS 10.13, *) {
-      try p.run()
-    } else {
-      p.launch()
-    }
+    try p.run()
 
     let dataOut = out.fileHandleForReading.readDataToEndOfFile()
     let dataErr = err.fileHandleForReading.readDataToEndOfFile()

--- a/Sources/IndexStore/IndexStoreOccurrence.swift
+++ b/Sources/IndexStore/IndexStoreOccurrence.swift
@@ -73,6 +73,15 @@ public struct IndexStoreOccurrence: ~Escapable, Sendable {
     return (Int(line), Int(column))
   }
 
+  public var description: String {
+    var result = "\(position.line):\(position.column) | \(symbol.description)"
+    relations.forEach { relation in
+      result += "\n  " + relation.description
+      return .continue
+    }
+    return result
+  }
+
   /// Specialized version of `IndexStoreSequence` that can have a lifetime dependence on a `IndexStoreOccurrence`.
   ///
   /// There currently doesn't seem to be a way to model this using the closure-taking `IndexStoreSequence`.

--- a/Sources/IndexStore/IndexStoreRecord.swift
+++ b/Sources/IndexStore/IndexStoreRecord.swift
@@ -13,7 +13,7 @@
 public import IndexStoreCAPI
 
 /// Representation of a record file within the Index Store that can be used to read its contents.
-public final class IndexStoreRecord: Sendable {
+public final class IndexStoreRecord: Sendable, CustomStringConvertible {
   @usableFromInline nonisolated(unsafe) let recordReader: indexstore_record_reader_t
   @usableFromInline let library: IndexStoreLibrary
 
@@ -143,4 +143,14 @@ public final class IndexStoreRecord: Sendable {
 
   // `record_reader_occurrences_of_symbols_apply_f` cannot be represented easily because we can't take an array of
   // `IndexStoreSymbol` as input to this function and has thus not been wrapped yet.
+
+  public var description: String {
+    return """
+      Symbols:
+      \(symbols.map {$0.description }.joined(separator: "\n"))
+
+      Occurrences:
+      \(occurrences.map { $0.description }.joined(separator: "\n"))
+      """
+  }
 }

--- a/Sources/IndexStore/IndexStoreSymbol.swift
+++ b/Sources/IndexStore/IndexStoreSymbol.swift
@@ -17,7 +17,7 @@ public import IndexStoreCAPI
 /// A symbol by itself does not have any source information associated with it. It just represents the declaration
 /// itself, `IndexStoreSymbolOccurrence` represents actual occurrences of symbols within a source file.
 public struct IndexStoreSymbol: ~Escapable, Sendable {
-  public struct Kind: RawRepresentable, Hashable, Sendable {
+  public struct Kind: RawRepresentable, Hashable, Sendable, CustomStringConvertible {
     public let rawValue: UInt16
 
     public static let unknown = Kind(INDEXSTORE_SYMBOL_KIND_UNKNOWN)
@@ -50,6 +50,41 @@ public struct IndexStoreSymbol: ~Escapable, Sendable {
     public static let concept = Kind(INDEXSTORE_SYMBOL_KIND_CONCEPT)
     public static let commentTag = Kind(INDEXSTORE_SYMBOL_KIND_COMMENTTAG)
 
+    public var description: String {
+      switch self {
+      case .unknown: return "unknown"
+      case .module: return "module"
+      case .namespace: return "namespace"
+      case .namespaceAlias: return "namespaceAlias"
+      case .macro: return "macro"
+      case .enum: return "enum"
+      case .struct: return "struct"
+      case .class: return "class"
+      case .protocol: return "protocol"
+      case .extension: return "extension"
+      case .union: return "union"
+      case .typealias: return "typealias"
+      case .function: return "function"
+      case .variable: return "variable"
+      case .field: return "field"
+      case .enumConstant: return "enumConstant"
+      case .instanceMethod: return "instanceMethod"
+      case .classMethod: return "classMethod"
+      case .staticMethod: return "staticMethod"
+      case .instanceProperty: return "instanceProperty"
+      case .classProperty: return "classProperty"
+      case .staticProperty: return "staticProperty"
+      case .constructor: return "constructor"
+      case .destructor: return "destructor"
+      case .conversionFunction: return "conversionFunction"
+      case .parameter: return "parameter"
+      case .using: return "using"
+      case .concept: return "concept"
+      case .commentTag: return "commentTag"
+      default: return "unknown symbol kind \(rawValue)"
+      }
+    }
+
     @inlinable
     public init(rawValue: UInt16) {
       self.rawValue = rawValue
@@ -61,7 +96,7 @@ public struct IndexStoreSymbol: ~Escapable, Sendable {
     }
   }
 
-  public struct SubKind: RawRepresentable, Hashable, Sendable {
+  public struct SubKind: RawRepresentable, Hashable, Sendable, CustomStringConvertible {
     public let rawValue: UInt16
 
     public static let none = SubKind(INDEXSTORE_SYMBOL_SUBKIND_NONE)
@@ -97,9 +132,38 @@ public struct IndexStoreSymbol: ~Escapable, Sendable {
     init(_ subKind: indexstore_symbol_subkind_t) {
       self.rawValue = UInt16(subKind.rawValue)
     }
+
+    public var description: String {
+      switch self {
+      case .none: return "none"
+      case .cxxCopyConstructor: return "cxxCopyConstructor"
+      case .cxxMoveConstructor: return "cxxMoveConstructor"
+      case .accessorGetter: return "accessorGetter"
+      case .accessorSetter: return "accessorSetter"
+      case .usingTypename: return "usingTypename"
+      case .usingValue: return "usingValue"
+      case .swiftAccessorWillSet: return "swiftAccessorWillSet"
+      case .swiftAccessorDidSet: return "swiftAccessorDidSet"
+      case .swiftAccessorAddressor: return "swiftAccessorAddressor"
+      case .swiftAccessorMutableAddressor: return "swiftAccessorMutableAddressor"
+      case .swiftExtensionOfStruct: return "swiftExtensionOfStruct"
+      case .swiftExtensionOfClass: return "swiftExtensionOfClass"
+      case .swiftExtensionOfEnum: return "swiftExtensionOfEnum"
+      case .swiftExtensionOfProtocol: return "swiftExtensionOfProtocol"
+      case .swiftPrefixOperator: return "swiftPrefixOperator"
+      case .swiftPostfixOperator: return "swiftPostfixOperator"
+      case .swiftInfixOperator: return "swiftInfixOperator"
+      case .swiftSubscript: return "swiftSubscript"
+      case .swiftAssociatedtype: return "swiftAssociatedtype"
+      case .swiftGenericTypeParam: return "swiftGenericTypeParam"
+      case .swiftAccessorRead: return "swiftAccessorRead"
+      case .swiftAccessorModify: return "swiftAccessorModify"
+      default: return "unknown SubKind \(rawValue)"
+      }
+    }
   }
 
-  public struct Properties: OptionSet, Sendable {
+  public struct Properties: OptionSet, Sendable, CustomStringConvertible {
     public let rawValue: UInt64
 
     public static let generic = Properties(INDEXSTORE_SYMBOL_PROPERTY_GENERIC)
@@ -122,6 +186,21 @@ public struct IndexStoreSymbol: ~Escapable, Sendable {
     @usableFromInline
     init(_ rawValue: indexstore_symbol_property_t) {
       self.rawValue = UInt64(rawValue.rawValue)
+    }
+
+    public var description: String {
+      var components: [String] = []
+      if self.contains(.generic) { components.append("generic") }
+      if self.contains(.templatePartialSpecialization) { components.append("templatePartialSpecialization") }
+      if self.contains(.templateSpecialization) { components.append("templateSpecialization") }
+      if self.contains(.unittest) { components.append("unittest") }
+      if self.contains(.ibAnnotated) { components.append("ibAnnotated") }
+      if self.contains(.ibOutletCollection) { components.append("ibOutletCollection") }
+      if self.contains(.gkInspectable) { components.append("gkInspectable") }
+      if self.contains(.local) { components.append("local") }
+      if self.contains(.protocolInterface) { components.append("protocolInterface") }
+      if self.contains(.swiftAsync) { components.append("swiftAsync") }
+      return components.joined(separator: ", ")
     }
   }
 
@@ -161,13 +240,19 @@ public struct IndexStoreSymbol: ~Escapable, Sendable {
     return Properties(rawValue: library.api.symbol_get_properties(symbol))
   }
 
-  /// The union of all roles with which the symbol occurs in the current record, including the relationship roles.
+  /// The union of all roles with which the symbol occurs in the current record
+  ///
+  /// Ie. the result of iterating over all `IndexStoreOccurrence`s of this symbol in the record and collecting their
+  /// roles.
   @inlinable
   public var roles: IndexStoreSymbolRoles {
     return IndexStoreSymbolRoles(rawValue: library.api.symbol_get_roles(symbol))
   }
 
-  /// Only the relationship roles with which the symbol occurs in the current record.
+  /// The roles with which this symbol is related to other symbol occurrences in the current record.
+  ///
+  /// Ie. the result of iterating over all `IndexStoreSymbolRelation`s of this symbol in the record and collecting
+  /// their roles.
   @inlinable
   public var relatedRoles: IndexStoreSymbolRoles {
     return IndexStoreSymbolRoles(rawValue: library.api.symbol_get_related_roles(symbol))
@@ -205,5 +290,22 @@ public struct IndexStoreSymbol: ~Escapable, Sendable {
       let stringRef = IndexStoreStringRef(library.api.symbol_get_codegen_name(symbol))
       return _overrideLifetime(stringRef, borrowing: self)
     }
+  }
+
+  var description: String {
+    var kindString = kind.description
+    if subKind != .none {
+      kindString += ".\(subKind)"
+    }
+    if !properties.isEmpty {
+      kindString += "(\(properties))"
+    }
+
+    return [
+      name.string,
+      kindString,
+      usr.string,
+      roles.description,
+    ].joined(separator: " | ")
   }
 }

--- a/Sources/IndexStore/IndexStoreSymbolRelation.swift
+++ b/Sources/IndexStore/IndexStoreSymbolRelation.swift
@@ -42,4 +42,8 @@ public struct IndexStoreSymbolRelation: ~Escapable, Sendable {
       return _overrideLifetime(symbol, borrowing: self)
     }
   }
+
+  var description: String {
+    return "\(roles) | \(symbol.usr.string)"
+  }
 }

--- a/Sources/IndexStore/IndexStoreSymbolRoles.swift
+++ b/Sources/IndexStore/IndexStoreSymbolRoles.swift
@@ -17,7 +17,7 @@ public import IndexStoreCAPI
 /// The roles are generally divided into normal roles and relationship roles. Normal roles specify in which role a
 /// symbol occurs in a source file. For an occurrence's related symbols, the relationship roles specify how the
 /// occurrence is related to the related symbol.
-public struct IndexStoreSymbolRoles: OptionSet, Sendable {
+public struct IndexStoreSymbolRoles: OptionSet, Sendable, CustomStringConvertible {
   public let rawValue: UInt64
 
   public static let declaration = IndexStoreSymbolRoles(INDEXSTORE_SYMBOL_ROLE_DECLARATION)
@@ -42,6 +42,33 @@ public struct IndexStoreSymbolRoles: OptionSet, Sendable {
   public static let containedBy = IndexStoreSymbolRoles(INDEXSTORE_SYMBOL_ROLE_REL_CONTAINEDBY)
   public static let ibTypeOf = IndexStoreSymbolRoles(INDEXSTORE_SYMBOL_ROLE_REL_IBTYPEOF)
   public static let specializationOf = IndexStoreSymbolRoles(INDEXSTORE_SYMBOL_ROLE_REL_SPECIALIZATIONOF)
+
+  public var description: String {
+    var roleStrings: [String] = []
+
+    if self.contains(.declaration) { roleStrings.append("declaration") }
+    if self.contains(.definition) { roleStrings.append("definition") }
+    if self.contains(.reference) { roleStrings.append("reference") }
+    if self.contains(.read) { roleStrings.append("read") }
+    if self.contains(.write) { roleStrings.append("write") }
+    if self.contains(.call) { roleStrings.append("call") }
+    if self.contains(.dynamic) { roleStrings.append("dynamic") }
+    if self.contains(.addressOf) { roleStrings.append("addressOf") }
+    if self.contains(.implicit) { roleStrings.append("implicit") }
+    if self.contains(.undefinition) { roleStrings.append("undefinition") }
+    if self.contains(.childOf) { roleStrings.append("childOf") }
+    if self.contains(.baseOf) { roleStrings.append("baseOf") }
+    if self.contains(.overrideOf) { roleStrings.append("overrideOf") }
+    if self.contains(.receivedBy) { roleStrings.append("receivedBy") }
+    if self.contains(.calledBy) { roleStrings.append("calledBy") }
+    if self.contains(.extendedBy) { roleStrings.append("extendedBy") }
+    if self.contains(.accessorOf) { roleStrings.append("accessorOf") }
+    if self.contains(.containedBy) { roleStrings.append("containedBy") }
+    if self.contains(.ibTypeOf) { roleStrings.append("ibTypeOf") }
+    if self.contains(.specializationOf) { roleStrings.append("specializationOf") }
+
+    return roleStrings.joined(separator: ", ")
+  }
 
   @inlinable
   public init(rawValue: UInt64) {

--- a/Sources/IndexStore/IndexStoreUnit.swift
+++ b/Sources/IndexStore/IndexStoreUnit.swift
@@ -14,7 +14,7 @@ public import Foundation
 public import IndexStoreCAPI
 
 /// Representation of a unit file within the Index Store that can be used to read its contents.
-public final class IndexStoreUnit: Sendable {
+public final class IndexStoreUnit: Sendable, CustomStringConvertible {
   @usableFromInline nonisolated(unsafe) let unitReader: indexstore_unit_reader_t
   @usableFromInline let library: IndexStoreLibrary
 
@@ -177,5 +177,35 @@ public final class IndexStoreUnit: Sendable {
         return body(IndexStoreUnitInclude(include: result!, library: self.library))
       }
     }
+  }
+
+  public var description: String {
+    var result = """
+      Module: \(moduleName.string)
+      Has Main File: \(hasMainFile)
+      Main File: \(mainFile.string)
+      Output File: \(outputFile.string)
+      Target: \(target.string)
+      Sysroot: \(sysrootPath.string)
+      Working Directory: \(workingDirectory.string)
+      Is System: \(isSystemUnit)
+      Is Module: \(isModuleUnit)
+      Is Debug: \(isDebugCompilation)
+      Provider Identifier: \(providerIdentifier.string)
+      Provider Version: \(providerVersion.string)
+      Modification Date: \(modificationDate)
+      Dependencies:
+      \(dependencies.map { $0.description }.joined(separator: "\n"))
+      """
+
+    let includesString = includes.map { $0.description }.joined(separator: "\n")
+    if !includesString.isEmpty {
+      result += """
+
+        Includes:
+        \(includesString)
+        """
+    }
+    return result
   }
 }

--- a/Sources/IndexStore/IndexStoreUnitDependency.swift
+++ b/Sources/IndexStore/IndexStoreUnitDependency.swift
@@ -13,7 +13,7 @@
 public import IndexStoreCAPI
 
 public struct IndexStoreUnitDependency: ~Escapable, Sendable {
-  public struct Kind: RawRepresentable, Sendable, Hashable {
+  public struct Kind: RawRepresentable, Sendable, Hashable, CustomStringConvertible {
     public let rawValue: UInt8
 
     public static let unit = Kind(INDEXSTORE_UNIT_DEPENDENCY_UNIT)
@@ -28,6 +28,15 @@ public struct IndexStoreUnitDependency: ~Escapable, Sendable {
     @usableFromInline
     init(_ kind: indexstore_unit_dependency_kind_t) {
       self.rawValue = UInt8(kind.rawValue)
+    }
+
+    public var description: String {
+      switch self {
+      case .unit: return "Unit"
+      case .record: return "Record"
+      case .file: return "File"
+      default: return "Unknown dependency kind \(rawValue)"
+      }
     }
   }
 
@@ -82,5 +91,15 @@ public struct IndexStoreUnitDependency: ~Escapable, Sendable {
       let stringRef = IndexStoreStringRef(library.api.unit_dependency_get_name(dependency))
       return _overrideLifetime(stringRef, borrowing: self)
     }
+  }
+
+  var description: String {
+    return [
+      kind.description,
+      isSystem ? "system" : "user",
+      moduleName.string,
+      filePath.string,
+      name.string,
+    ].filter { !$0.isEmpty }.joined(separator: " | ")
   }
 }

--- a/Sources/IndexStore/IndexStoreUnitInclude.swift
+++ b/Sources/IndexStore/IndexStoreUnitInclude.swift
@@ -48,4 +48,8 @@ public struct IndexStoreUnitInclude: ~Escapable, Sendable {
       return _overrideLifetime(stringRef, borrowing: self)
     }
   }
+
+  var description: String {
+    return "\(sourcePath.string):\(line) | \(targetPath.string)"
+  }
 }

--- a/Sources/index-dump/LibIndexStoreProvider.swift
+++ b/Sources/index-dump/LibIndexStoreProvider.swift
@@ -1,0 +1,75 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+
+#if os(Windows)
+import WinSDK
+#endif
+
+/// Provides utilities to discover and locate libIndexStore in the system.
+enum LibIndexStoreProvider {
+  /// Returns the path to the given tool, as found by `xcrun --find` on macOS, `which` on Linux and `where` on Windows.
+  private static func findTool(name: String) -> URL? {
+    #if os(macOS)
+    let cmd = ["/usr/bin/xcrun", "--find", name]
+    #elseif os(Windows)
+    var buf = [WCHAR](repeating: 0, count: Int(MAX_PATH))
+    GetWindowsDirectoryW(&buf, UINT(MAX_PATH))
+    var wherePath = String(decodingCString: &buf, as: UTF16.self)
+    wherePath = (wherePath as NSString).appendingPathComponent("system32")
+    wherePath = (wherePath as NSString).appendingPathComponent("where.exe")
+    let cmd = [wherePath, name]
+    #else
+    let cmd = ["/usr/bin/which", name]
+    #endif
+
+    let process = Process()
+    process.executableURL = URL(fileURLWithPath: cmd[0])
+    process.arguments = Array(cmd.dropFirst())
+    let pipe = Pipe()
+    process.standardOutput = pipe
+
+    try? process.run()
+    process.waitUntilExit()
+    guard process.terminationStatus == 0 else { return nil }
+
+    let data = pipe.fileHandleForReading.readDataToEndOfFile()
+    var path = String(decoding: data, as: UTF8.self)
+    #if os(Windows)
+    path = String((path.split { $0.isNewline })[0])
+    #endif
+    return URL(fileURLWithPath: path.trimmingCharacters(in: .whitespacesAndNewlines))
+  }
+
+  /// Find libIndexStore dylib path in the default toolchain.
+  static func inferLibPath() -> URL? {
+    guard let swiftURL = findTool(name: "swift") else {
+      return nil
+    }
+
+    let toolchainURL = swiftURL.deletingLastPathComponent().deletingLastPathComponent()
+
+    #if os(macOS)
+    let libURL = toolchainURL.appending(components: "lib", "libIndexStore.dylib")
+    #elseif os(Windows)
+    let libURL = toolchainURL.appending(components: "bin", "libIndexStore.dll")
+    #else
+    let libURL = toolchainURL.appending(components: "lib", "libIndexStore.so")
+    #endif
+
+    guard FileManager.default.fileExists(atPath: libURL.path) else {
+      return nil
+    }
+    return libURL
+  }
+}

--- a/Sources/index-dump/index-dump.swift
+++ b/Sources/index-dump/index-dump.swift
@@ -1,0 +1,112 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import ArgumentParser
+import Foundation
+import IndexStore
+
+#if os(Windows)
+import WinSDK
+#endif
+
+@main
+struct IndexDump: AsyncParsableCommand {
+  static let configuration = CommandConfiguration(
+    abstract: "Dumps the content of unit or record files from an Index Store."
+  )
+
+  @Argument(help: "Name of the unit/record to print")
+  var unitOrRecordName: String
+
+  @Option(
+    name: .customLong("lib-index-store"),
+    help: "Path to libIndexStore. Inferred from the default toolchain if omitted."
+  )
+  var libIndexStore: String?
+
+  @Option(
+    name: .customLong("index-store"),
+    help:
+      "Path to the index store directory. This should be the directory containing the v5 directory. Inferred from the current working directory if omitted."
+  )
+  var indexStore: String?
+
+  enum Mode: String, ExpressibleByArgument {
+    case unit, record
+  }
+
+  var indexStorePath: URL {
+    get throws {
+      if let explicit = indexStore {
+        return URL(fileURLWithPath: explicit)
+      }
+
+      var indexStorePath = URL(filePath: FileManager.default.currentDirectoryPath)
+      while !indexStorePath.isRoot {
+        if FileManager.default.fileExists(atPath: indexStorePath.appending(component: "v5").filePath) {
+          return indexStorePath
+        }
+        indexStorePath.deleteLastPathComponent()
+      }
+
+      throw ValidationError(
+        "Could not infer store path. Please change the working directory to a have a parent directory named v5 or explicitly specify --index-store."
+      )
+    }
+  }
+
+  var libIndexStorePath: URL {
+    get throws {
+      if let explicit = libIndexStore { return URL(fileURLWithPath: explicit) }
+
+      guard let libURL = LibIndexStoreProvider.inferLibPath() else {
+        throw ValidationError(
+          "Could not find 'swift' to infer toolchain path. Please specify --lib-index-store explicitly."
+        )
+      }
+      return libURL
+    }
+  }
+
+  func run() async throws {
+    let lib = try await IndexStoreLibrary.at(dylibPath: libIndexStorePath)
+    let indexStorePath = try self.indexStorePath
+    let store = try lib.indexStore(at: indexStorePath)
+
+    if let unit = try? store.unit(named: unitOrRecordName) {
+      print(unit)
+    } else if let record = try? store.record(named: unitOrRecordName) {
+      print(record)
+    } else {
+      throw ValidationError("Could not find unit or record named \(unitOrRecordName) in \(indexStorePath)")
+    }
+  }
+}
+
+extension URL {
+  package var filePath: String {
+    return self.withUnsafeFileSystemRepresentation { filePathPtr in
+      return String(cString: filePathPtr!)
+    }
+  }
+
+  /// Assuming this URL is a file URL, checks if it looks like a root path. This is a string check, ie. the return
+  /// value for a path of `"/foo/.."` would be `false`. An error will be thrown is this is a non-file URL.
+  package var isRoot: Bool {
+    #if os(Windows)
+    return filePath.withCString(encodedAs: UTF16.self, PathCchIsRoot)
+    #else
+    return filePath == "/"
+    #endif
+  }
+
+}

--- a/Tests/IndexStoreTests/DescriptionTests.swift
+++ b/Tests/IndexStoreTests/DescriptionTests.swift
@@ -1,0 +1,140 @@
+import Testing
+
+@Suite
+struct DescriptionTests {
+  @Test func swiftUnitDescription() async throws {
+    let project = TestProject(swiftFiles: [
+      "test.swift": """
+      func testFunc() {}
+      """
+    ])
+    try await project.withIndexStore { indexStore in
+      let unitName = try #require(indexStore.unitNames(sorted: false).map { $0.string }.only)
+      let unit = try indexStore.unit(named: unitName)
+      let description = unit.description
+
+      #expect(
+        try Regex(
+          #"""
+          Module: test
+          Has Main File: true
+          Main File: .*[\/]test.swift
+          Output File: .*[\/]test.o
+          Target: .*-.*-.*
+          Sysroot: .*
+          Working Directory: .*[\/]sources
+          Is System: false
+          Is Module: false
+          Is Debug: true
+          Provider Identifier: swift
+          Provider Version: .*
+          Modification Date: 20.*
+          Dependencies:
+          Unit \| system \| Swift \| .*[\/]Swift.swiftmodule[\/].*swiftinterface
+          Record \| user \| .*[\/]test.swift \| test.swift-.*
+          """#
+        ).wholeMatch(in: description) != nil,
+        """
+        Description did not match expected pattern. Got:
+        \(description)
+        """
+      )
+    }
+  }
+
+  @Test func cUnitDescription() async throws {
+    let project = TestProject(
+      clangFiles: [
+        "Test.c": """
+        #include "Test.h"
+        """
+      ],
+      supplementaryFiles: ["Test.h": ""]
+    )
+    try await project.withIndexStore { indexStore in
+      let unitName = try #require(indexStore.unitNames(sorted: false).map { $0.string }.only)
+      let unit = try indexStore.unit(named: unitName)
+      let description = unit.description
+
+      #expect(
+        try Regex(
+          #"""
+          Module: .*
+          Has Main File: true
+          Main File: .*[\/]Test.c
+          Output File: .*[\/]Test.o
+          Target: .*-.*-.*
+          Sysroot: .*
+          Working Directory: .*[\/]sources
+          Is System: false
+          Is Module: false
+          Is Debug: true
+          Provider Identifier: clang
+          Provider Version: .*
+          Modification Date: 20.*
+          Dependencies:
+          File \| user \| .*[\/]Test.c
+          File \| user \| .*[\/]Test.h
+          Includes:
+          .*[\/]Test.c:1 \| .*[\/]Test.h
+          """#
+        ).wholeMatch(in: description) != nil,
+        """
+        Description did not match expected pattern. Got:
+        \(description)
+        """
+      )
+
+    }
+  }
+
+  @Test func recordDescription() async throws {
+    let project = TestProject(swiftFiles: [
+      "test.swift": """
+      struct Foo {
+        subscript(x: Int) -> Int { x }
+        func testFunc() async {}
+      }
+      """
+    ])
+    try await project.withIndexStore { indexStore in
+      let unitName = try #require(indexStore.unitNames(sorted: false).map { $0.string }.only)
+      let unit = try indexStore.unit(named: unitName)
+
+      let recordNames = unit.dependencies.compactMap { dep in
+        dep.kind == .record ? dep.name.string : nil
+      }
+      let recordName = try #require(recordNames.only)
+      let record = try indexStore.record(named: recordName)
+      let description = record.description
+
+      #expect(
+        description == """
+          Symbols:
+          init() | constructor | s:4test3FooVACycfc | definition, implicit, childOf
+          Foo | struct | s:4test3FooV | definition
+          subscript(_:) | instanceProperty.swiftSubscript | s:4test3FooVyS2icip | definition, childOf
+          x | parameter | s:4test3FooVyS2icip1xL_Sivp | definition, childOf
+          Int | struct | s:Si | reference
+          getter:subscript(_:) | instanceMethod.accessorGetter | s:4test3FooVyS2icig | definition, childOf, accessorOf
+          testFunc() | instanceMethod(swiftAsync) | s:4test3FooV0A4FuncyyYaF | definition, childOf
+
+          Occurrences:
+          1:8 | init() | constructor | s:4test3FooVACycfc | definition, implicit, childOf
+            childOf | s:4test3FooV
+          1:8 | Foo | struct | s:4test3FooV | definition
+          2:3 | subscript(_:) | instanceProperty.swiftSubscript | s:4test3FooVyS2icip | definition, childOf
+            childOf | s:4test3FooV
+          2:13 | x | parameter | s:4test3FooVyS2icip1xL_Sivp | definition, childOf
+            childOf | s:4test3FooVyS2icip
+          2:16 | Int | struct | s:Si | reference
+          2:24 | Int | struct | s:Si | reference
+          2:28 | getter:subscript(_:) | instanceMethod.accessorGetter | s:4test3FooVyS2icig | definition, childOf, accessorOf
+            childOf, accessorOf | s:4test3FooVyS2icip
+          3:8 | testFunc() | instanceMethod(swiftAsync) | s:4test3FooV0A4FuncyyYaF | definition, childOf
+            childOf | s:4test3FooV
+          """
+      )
+    }
+  }
+}

--- a/Tests/IndexStoreTests/IndexStoreTests.swift
+++ b/Tests/IndexStoreTests/IndexStoreTests.swift
@@ -1,3 +1,15 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
 import Foundation
 import ISDBTibs
 import IndexStore
@@ -204,7 +216,9 @@ struct IndexStoreTests {
         guard occurrence.symbol.name.string == "bar()" else {
           return .continue
         }
-        #expect(occurrence.symbol.roles == [.definition, .reference, .call, .calledBy, .containedBy])
+        #expect(
+          occurrence.symbol.roles == [.definition, .reference, .call, .calledBy, .containedBy]
+        )
         #expect(occurrence.symbol.relatedRoles == [.calledBy, .containedBy])
         return .continue
       }
@@ -238,6 +252,5 @@ struct IndexStoreTests {
       #expect(include.target.hasSuffix("test.h"))
       #expect(include.line == 2)
     }
-    print()
   }
 }

--- a/Tests/IndexStoreTests/TestProject.swift
+++ b/Tests/IndexStoreTests/TestProject.swift
@@ -65,12 +65,17 @@ struct TestProject {
       "-index-store-path", indexDir.filePath,
       "-o", fileUrl.deletingPathExtension().appendingPathExtension("o").filePath,
       "-index-ignore-system-modules",
+      "-disable-implicit-concurrency-module-import",
+      "-disable-implicit-string-processing-module-import",
     ]
     if let sdk = defaultSDKPath {
       compilerArguments += ["-sdk", sdk]
     }
 
-    _ = try Process.tibs_checkNonZeroExit(arguments: compilerArguments)
+    _ = try Process.tibs_checkNonZeroExit(
+      arguments: compilerArguments,
+      workingDirectory: fileUrl.deletingLastPathComponent()
+    )
   }
 
   private func indexClangFile(at fileUrl: URL, indexDir: URL) throws {
@@ -83,6 +88,9 @@ struct TestProject {
       "-o", fileUrl.deletingPathExtension().appendingPathExtension("o").filePath,
     ]
 
-    _ = try Process.tibs_checkNonZeroExit(arguments: compilerArguments)
+    _ = try Process.tibs_checkNonZeroExit(
+      arguments: compilerArguments,
+      workingDirectory: fileUrl.deletingLastPathComponent()
+    )
   }
 }


### PR DESCRIPTION
This has a similar function as `c-index-test core -print-unit` and `c-index-test core -print-record` but doesn’t require building all of LLVM to use.

Fixes #264