### PR TITLE
Fix non-deterministic test failures on Amazon Linux 2 due to incorrectly set working directories

### DIFF
--- a/Sources/ISDBTibs/Process.swift
+++ b/Sources/ISDBTibs/Process.swift
@@ -22,8 +22,7 @@ extension Process {
   /// Runs a subprocess and returns its output as a String if it has a zero exit.
   package static func tibs_checkNonZeroExit(
     arguments: [String],
-    environment: [String: String]? = nil,
-    workingDirectory: URL? = nil
+    environment: [String: String]? = nil
   ) throws -> String {
     let p = Process()
     let out = Pipe()
@@ -36,7 +35,14 @@ extension Process {
     }
     p.standardOutput = out
     p.standardError = err
-    p.currentDirectoryURL = workingDirectory
+
+    // IMPORTANT: If you are tempted to add `p.currentDirectoryPath` here, don't.
+    // On Amazon Linux 2 `_CFPosixSpawnFileActionsChdir` is not implemented because it AL2 doesn't support
+    // posix_spawn_file_actions_addchdir_np. Because of this, swift-corelibs-foundation changes the working directory of
+    // the current process.
+    // https://github.com/swiftlang/swift-corelibs-foundation/blob/0b23e798e921fd14ff59b37c9145021cd60e0aa9/Sources/Foundation/Process.swift#L989
+    // If we run multiple sub-processes concurrently, this races to change global state, resulting
+    // in non-deterministic working directories and spurious test failures.
 
     try p.run()
 

--- a/Tests/IndexStoreTests/TestProject.swift
+++ b/Tests/IndexStoreTests/TestProject.swift
@@ -57,6 +57,7 @@ struct TestProject {
       swiftc.filePath,
       "-index-file",
       fileUrl.filePath,
+      "-working-directory", fileUrl.deletingLastPathComponent().filePath,
       "-index-store-path", indexDir.filePath,
       "-o", fileUrl.deletingPathExtension().appendingPathExtension("o").filePath,
       "-index-ignore-system-modules",
@@ -67,10 +68,7 @@ struct TestProject {
       compilerArguments += ["-sdk", sdk]
     }
 
-    _ = try Process.tibs_checkNonZeroExit(
-      arguments: compilerArguments,
-      workingDirectory: fileUrl.deletingLastPathComponent()
-    )
+    _ = try Process.tibs_checkNonZeroExit(arguments: compilerArguments)
   }
 
   private func indexClangFile(at fileUrl: URL, indexDir: URL) throws {
@@ -79,13 +77,11 @@ struct TestProject {
       clang.filePath,
       "-fsyntax-only",
       fileUrl.filePath,
+      "-working-directory", fileUrl.deletingLastPathComponent().filePath,
       "-index-store-path", indexDir.filePath,
       "-o", fileUrl.deletingPathExtension().appendingPathExtension("o").filePath,
     ]
 
-    _ = try Process.tibs_checkNonZeroExit(
-      arguments: compilerArguments,
-      workingDirectory: fileUrl.deletingLastPathComponent()
-    )
+    _ = try Process.tibs_checkNonZeroExit(arguments: compilerArguments)
   }
 }


### PR DESCRIPTION
On Amazon Linux 2 `_CFPosixSpawnFileActionsChdir` is not implemented because it AL2 doesn't support posix_spawn_file_actions_addchdir_np. Because of this, swift-corelibs-foundation changes the working directory of the current process.

https://github.com/swiftlang/swift-corelibs-foundation/blob/0b23e798e921fd14ff59b37c9145021cd60e0aa9/Sources/Foundation/Process.swift#L989

If we run multiple sub-processes concurrently, this races to change global state, resulting in non-deterministic working directories and spurious test failures. Instead set the working directory by passing `-working-directory` to the indexing processes.

rdar://174708032