### PR TITLE
[6.4] Change package dependencies to release/6.4.x

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -29,7 +29,7 @@ var dependencies: [Package.Dependency] {
     ]
   } else {
     return [
-      .package(url: "https://github.com/swiftlang/swift-lmdb.git", branch: "main"),
+      .package(url: "https://github.com/swiftlang/swift-lmdb.git", branch: "release/6.4.x"),
       .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.5.1"),
     ]
   }


### PR DESCRIPTION
- **Explanation**: Update the branch for package dependencies to `release/6.4.x`
- **Scope**: Package description
- **Issues**: N/A
- **Original PRs**: N/A, this is a `release/6.4.x` branch specific change
- **Risk**: Low, at this point there's no much difference between `main` and `release/6.4.x` in the dependencies
- **Testing**: Passes the current test suite
