### PR TITLE
Re-import explicitly processed units even if their mtime is unchanged

### DIFF
--- a/Sources/IndexStoreDB_Database/ImportTransaction.cpp
+++ b/Sources/IndexStoreDB_Database/ImportTransaction.cpp
@@ -402,7 +402,8 @@ void ImportTransaction::commit() {
   return Impl->commit();
 }
 
-UnitDataImport::UnitDataImport(ImportTransaction &import, StringRef unitName, llvm::sys::TimePoint<> modTime)
+UnitDataImport::UnitDataImport(ImportTransaction &import, StringRef unitName, llvm::sys::TimePoint<> modTime,
+                               bool ignoreModTime)
 : Import(import), UnitName(unitName), ModTime(modTime), IsSystem(false) {
 
   auto dbUnit = import._impl()->getUnitInfo(makeIDCodeFromString(unitName));
@@ -420,7 +421,7 @@ UnitDataImport::UnitDataImport(ImportTransaction &import, StringRef unitName, ll
   PrevTargetCode = dbUnit.TargetCode;
   PrevSysrootCode = dbUnit.SysrootCode;
 
-  if (dbUnit.ModTime == modTime) {
+  if (!ignoreModTime && dbUnit.ModTime == modTime) {
     IsUpToDate = true;
     return;
   }

--- a/Sources/IndexStoreDB_Database/include/IndexStoreDB_Database/ImportTransaction.h
+++ b/Sources/IndexStoreDB_Database/include/IndexStoreDB_Database/ImportTransaction.h
@@ -80,7 +80,12 @@ class INDEXSTOREDB_EXPORT UnitDataImport {
   std::vector<UnitInfo::Provider> ProviderDepends;
 
 public:
-  UnitDataImport(ImportTransaction &import, StringRef unitName, llvm::sys::TimePoint<> modTime);
+  /// \param ignoreModTime If true, treat the unit as out-of-date even if its modification time matches the one already
+  /// recorded in the database, forcing a re-import. This is used when a caller knows that the unit's contents changed
+  /// but its modification time might not have (e.g. because the file system's timestamp granularity is too coarse to
+  /// distinguish two writes in quick succession).
+  UnitDataImport(ImportTransaction &import, StringRef unitName, llvm::sys::TimePoint<> modTime,
+                 bool ignoreModTime = false);
   ~UnitDataImport();
 
   IDCode getUnitCode() const { return UnitCode; }

--- a/Sources/IndexStoreDB_Index/IndexDatastore.cpp
+++ b/Sources/IndexStoreDB_Index/IndexDatastore.cpp
@@ -88,9 +88,15 @@ struct UnitEventInfo {
   bool isInitialScan;
   /// Whether this is an explicit enqueue of a dependency unit for processing, while `UseExplicitOutputUnits` is enabled.
   bool isDependency;
+  /// Whether to re-import the unit even if its modification time matches the one already recorded in the database.
+  /// This is set when a caller explicitly requests processing of a unit that it knows was just re-generated, so that
+  /// the new contents are loaded even if the file system's timestamp granularity didn't distinguish the two writes.
+  bool ignoreModTime;
 
-  UnitEventInfo(IndexStore::UnitEvent::Kind kind, std::string name, bool isInitialScan, bool isDependency = false)
-  : kind(kind), name(std::move(name)), isInitialScan(isInitialScan), isDependency(isDependency) {}
+  UnitEventInfo(IndexStore::UnitEvent::Kind kind, std::string name, bool isInitialScan, bool isDependency = false,
+                bool ignoreModTime = false)
+  : kind(kind), name(std::move(name)), isInitialScan(isInitialScan), isDependency(isDependency),
+    ignoreModTime(ignoreModTime) {}
 };
 
 struct PollUnitsState {
@@ -158,7 +164,7 @@ public:
   void checkUnitContainingFileIsOutOfDate(StringRef file);
 
 private:
-  void registerUnit(StringRef UnitName, bool isInitialScan, std::shared_ptr<UnitProcessingSession> processSession);
+  void registerUnit(StringRef UnitName, bool isInitialScan, std::shared_ptr<UnitProcessingSession> processSession, bool ignoreModTime = false);
   void removeUnit(StringRef UnitName);
 };
 
@@ -425,7 +431,7 @@ void StoreUnitRepo::onFilesChange(std::vector<UnitEventInfo> evts,
       case IndexStore::UnitEvent::Kind::Added:
       case IndexStore::UnitEvent::Kind::Modified:
         if (!shouldIgnore(evt)) {
-          registerUnit(evt.name, evt.isInitialScan, processSession);
+          registerUnit(evt.name, evt.isInitialScan, processSession, evt.ignoreModTime);
         }
         break;
       case IndexStore::UnitEvent::Kind::Removed:
@@ -453,7 +459,7 @@ void StoreUnitRepo::onFilesChange(std::vector<UnitEventInfo> evts,
   }
 }
 
-void StoreUnitRepo::registerUnit(StringRef unitName, bool isInitialScan, std::shared_ptr<UnitProcessingSession> processSession) {
+void StoreUnitRepo::registerUnit(StringRef unitName, bool isInitialScan, std::shared_ptr<UnitProcessingSession> processSession, bool ignoreModTime) {
   std::string Error;
   auto optModTime = IdxStore->getUnitModificationTime(unitName, Error);
   if (!optModTime) {
@@ -493,7 +499,7 @@ void StoreUnitRepo::registerUnit(StringRef unitName, bool isInitialScan, std::sh
   // Returns true if an error occurred.
   auto importUnit = [&]() -> bool {
     ImportTransaction import(SymIndex->getDBase());
-    UnitDataImport unitImport(import, unitName, unitModTime);
+    UnitDataImport unitImport(import, unitName, unitModTime, ignoreModTime);
     unitCode = unitImport.getUnitCode();
     needDatabaseUpdate = !unitImport.isUpToDate();
     optIsSystem = unitImport.getIsSystem();
@@ -752,7 +758,13 @@ void StoreUnitRepo::processUnitsForOutputPathsAndWait(ArrayRef<StringRef> output
   std::vector<UnitEventInfo> events;
   for (StringRef outputPath : outputPaths) {
     IdxStore->getUnitNameFromOutputPath(outputPath, nameBuf);
-    events.emplace_back(IndexStore::UnitEvent::Kind::Modified, nameBuf.str(), /*isInitialScan=*/false);
+    // The caller explicitly requests processing of these output paths because it knows their units were just
+    // re-generated. Pass `ignoreModTime` so that we re-import them even if the unit's modification time happens to
+    // match the one already in the database, which can occur when two writes land within the same file-system
+    // timestamp tick (observed e.g. on Windows). Otherwise the freshly indexed symbols would not become queryable
+    // until the unit is eventually picked up through file watching.
+    events.emplace_back(IndexStore::UnitEvent::Kind::Modified, nameBuf.str(), /*isInitialScan=*/false,
+                        /*isDependency=*/false, /*ignoreModTime=*/true);
   }
   auto session = makeUnitProcessingSession();
   session->process(std::move(events), /*waitForProcessing=*/true);


### PR DESCRIPTION
`processUnitsForOutputPathsAndWait` is the explicit "I just regenerated these units, load them now" API that clients like SourceKit-LSP call after re-indexing. Its effect is silently dropped when the rewritten unit's modification time exactly equals the one in the database: `UnitDataImport` treats the unit as up to date and never re-reads it. This is easy to hit when a unit is rewritten within one file-system timestamp tick, especially on coarse-granularity file systems — where we've seen the resulting flakiness on Windows (a workspace symbol query returning 0 results right after indexing reports finished).

This threads an `ignoreModTime` flag from `processUnitsForOutputPathsAndWait` down to `UnitDataImport` so units processed through this explicit API are always re-imported. The flag is applied before the up-to-date short-circuit, so the previous-dependency bookkeeping used for cleanup is still populated. All paths that only *guess* whether a unit changed (file watching, `pollForUnitChangesAndWait`, the initial scan) keep comparing modification times, so this adds no extra work when scanning.

Speculative fix for rdar://178781218 / swiftlang/sourcekit-lsp#2687. I have no captured failing log, so the same-tick collision is a strong inference; the definitive check is to point sourcekit-lsp's `indexstore-db` dependency at this branch and stress-loop `testEnsureSymbolsLoadedIntoIndexstoreDbWhenIndexingHasFinished`, ideally on Windows.
